### PR TITLE
Create metadata.json

### DIFF
--- a/broker/message/message_metadata.go
+++ b/broker/message/message_metadata.go
@@ -94,6 +94,7 @@ func (m Message) MetadataDeleteRequest() (*MetadataDeleteRequest, error) {
 // Subtypes
 
 type MetadataFile struct {
-	ID   string `json:"id"`
-	Path string `json:"path"`
+	ID    string `json:"id"`
+	Path  string `json:"path"`
+	Title string `json:"title,omitempty"`
 }


### PR DESCRIPTION
This closes #17.
For a message like:

```json
{
  "messageHeader": {
    "messageId": "9e8f3cfc-29c2-11e7-93ae-92361f002671",
    "messageType": "MetadataCreate",
    "messageClass": "Command"
  },
  "messageBody": {
    "datasetUuid": "a7e83002-29c1-11e7-93ae-92361f002671",
    "datasetTitle": "IKEA2",
    "files": [
      {
        "id": "ec2d4928-29c1-11e7-93ae-92361f002671",
        "path": "s3://rdss-prod-figshare-0132/bird-sounds.mp3",
        "title": "Bird sounds"
      },
      {
        "id": "0dc88052-29c2-11e7-93ae-92361f002671",
        "path": "s3://rdss-prod-figshare-0132/woodpigeon-pic.jpg",
        "title": "Woodpigeon Picture"
      }
    ]
  }
}
```

A new file `/metadata/metadata.json` should be included in the transfer with the following contents:

```json
[
   {
      "filename":"objects/bird-sounds.mp3",
      "dc.title":"Bird sounds"
   },
   {
      "filename":"objects/woodpigeon-pic.jpg",
      "dc.title":"Woodpigeon Picture"
   }
]
```