### PR TITLE
Problem: metadata of dataset is missing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 ---
 language: go
 go:
-  - 1.8.1
-install: make tools
+  - 1.8.3
+install:
+  - make tools
+  - go get github.com/mattn/goveralls
 script:
+  - $HOME/gopath/bin/goveralls -service=travis-ci
   - make vet vendor-status test
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# RDSS Archivematica Channel Adapter [![Build Status](https://travis-ci.com/JiscRDSS/rdss-archivematica-channel-adapter.svg?token=XEKi3UuVjsxnJD1KeZsi&branch=master)](https://travis-ci.com/JiscRDSS/rdss-archivematica-channel-adapter)
+[![Travis CI](https://travis-ci.org/JiscRDSS/rdss-archivematica-channel-adapter.svg?branch=master)](https://travis-ci.org/JiscRDSS/rdss-archivematica-channel-adapter) [![GoDoc](https://godoc.org/github.com/JiscRDSS/rdss-archivematica-channel-adapter?status.svg)](https://godoc.org/github.com/JiscRDSS/rdss-archivematica-channel-adapter) [![Coverage Status](https://coveralls.io/repos/github/JiscRDSS/rdss-archivematica-channel-adapter/badge.svg?branch=master)](https://coveralls.io/github/JiscRDSS/rdss-archivematica-channel-adapter?branch=master) [![Go Report Card](https://goreportcard.com/badge/JiscRDSS/rdss-archivematica-channel-adapter)](https://goreportcard.com/report/JiscRDSS/rdss-archivematica-channel-adapter) [![Sourcegraph](https://sourcegraph.com/github.com/JiscRDSS/rdss-archivematica-channel-adapter/-/badge.svg)](https://sourcegraph.com/github.com/JiscRDSS/rdss-archivematica-channel-adapter?badge)
+
+# RDSS Archivematica Channel Adapter
 
 - [Introduction](#introduction)
 - [Usage](#usage)

--- a/amclient/amclient.go
+++ b/amclient/amclient.go
@@ -111,9 +111,12 @@ func SetFs(fs afero.Fs) ClientOpt {
 	}
 }
 
+// RequestOpt is a function type used to alter requests.
 type RequestOpt func(*http.Request)
 
-func WithRequestAcceptXml() RequestOpt {
+// WithRequestAcceptXML sets the Accept header to "application/xml". This is
+// needed when consuming endpoints that require this configuration.
+func WithRequestAcceptXML() RequestOpt {
 	return func(req *http.Request) {
 		req.Header.Set("Accept", "application/xml")
 	}

--- a/amclient/processing_config.go
+++ b/amclient/processing_config.go
@@ -8,6 +8,8 @@ import (
 
 const processingConfigBasePath = "api/processing-configuration"
 
+// ProcessingConfigService is an interface for interfacing with the processing
+// configuration endpoints of the Dashboard API.
 type ProcessingConfigService interface {
 	Get(context.Context, string) (*ProcessingConfig, *Response, error)
 }
@@ -20,6 +22,8 @@ type ProcessingConfigOp struct {
 
 var _ ProcessingConfigService = &ProcessingConfigOp{}
 
+// ProcessingConfig represents the processing configuration document returned
+// by the Dashboard API.
 type ProcessingConfig struct {
 	bytes.Buffer
 }
@@ -28,7 +32,7 @@ type ProcessingConfig struct {
 func (s *ProcessingConfigOp) Get(ctx context.Context, name string) (*ProcessingConfig, *Response, error) {
 	path := fmt.Sprintf("%s/%s/", processingConfigBasePath, name)
 
-	req, err := s.client.NewRequest(ctx, "GET", path, nil, WithRequestAcceptXml())
+	req, err := s.client.NewRequest(ctx, "GET", path, nil, WithRequestAcceptXML())
 	if err != nil {
 		return nil, nil, err
 	}

--- a/amclient/transfer.go
+++ b/amclient/transfer.go
@@ -8,6 +8,8 @@ import (
 
 const transferBasePath = "api/transfer"
 
+// TransferService is an interface for interfacing with the Transfer endpoints
+// of the Dashboard API.
 type TransferService interface {
 	Start(context.Context, *TransferStartRequest) (*TransferStartResponse, *Response, error)
 	Approve(context.Context, *TransferApproveRequest) (*TransferApproveResponse, *Response, error)
@@ -87,6 +89,8 @@ type TransferUnapprovedResponse struct {
 	Results []*TransferUnapprovedResponseResult `json:"results"`
 }
 
+// TransferUnapprovedResponseResult represents a result of
+// TransferUnapprovedResponse.
 type TransferUnapprovedResponseResult struct {
 	Type      string `json:"type"`
 	Directory string `json:"directory"`

--- a/amclient/transfer_session.go
+++ b/amclient/transfer_session.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 
 	"path"
@@ -74,7 +75,15 @@ func (c *Client) TransferSession(name string, depositFs afero.Fs) (*TransferSess
 // Create creates a file in the filesystem, returning the file and an error, if
 // any happens.
 func (s *TransferSession) Create(name string) (afero.File, error) {
-	return s.fs.Create(name)
+	err := s.fs.MkdirAll(filepath.Dir(name), os.FileMode(0755))
+	if err != nil {
+		return nil, err
+	}
+	f, err := s.fs.Create(name)
+	if err != nil {
+		return nil, err
+	}
+	return f, nil
 }
 
 // ProcessingConfig inclues a processing configuration (processingMCP.xml)

--- a/broker/backend/kinesis/processor_test.go
+++ b/broker/backend/kinesis/processor_test.go
@@ -71,6 +71,10 @@ func (d myKinesis) DescribeStream(input *kinesis.DescribeStreamInput) (*kinesis.
 	return output, nil
 }
 
+func (d myKinesis) DescribeStreamPages(*kinesis.DescribeStreamInput, func(*kinesis.DescribeStreamOutput, bool) bool) error {
+	return nil
+}
+
 type myDynamo struct {
 	dynamodbiface.DynamoDBAPI
 }

--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -94,15 +94,18 @@ func (c *ConsumerImpl) handleMetadataCreateRequest(msg *message.Message) error {
 			f, err = t.Create(name)
 			if err != nil {
 				iErr = err
+				c.logger.Errorf("Error creating %s: %v", name, err)
 				return
 			}
 			defer f.Close()
+			c.logger.Debugf("Saving %s into %s", file.Path, f.Name())
 			n, err = c.s3.Download(c.ctx, f, file.Path)
 			if err != nil {
 				iErr = err
+				c.logger.Errorf("Error downloading %s: %v", file.Path, err)
 				return
 			}
-			c.logger.Debugf("Downloaded %s - %d bytes written", file.Path, n)
+			c.logger.Debugf("%d bytes written", n)
 			t.DescribeFile(name, fileMetadata(name, file))
 		}()
 		if iErr != nil {

--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -78,6 +78,7 @@ func (c *ConsumerImpl) handleMetadataCreateRequest(msg *message.Message) error {
 	if err != nil {
 		c.logger.Warningf("Failed to download `automated` processing configuration: %s", err)
 	}
+	t.Describe(datasetMetadata(body))
 	for _, file := range body.Files {
 		name := getFilename(file.Path)
 		if name == "" {
@@ -121,6 +122,12 @@ func getFilename(path string) string {
 		return ""
 	}
 	return strings.TrimPrefix(u.Path, "/")
+}
+
+func datasetMetadata(f *message.MetadataCreateRequest) *amclient.FileMetadata {
+	return &amclient.FileMetadata{
+		DcTitle: f.Title,
+	}
 }
 
 func fileMetadata(name string, f *message.MetadataFile) *amclient.FileMetadata {


### PR DESCRIPTION
This PR updates the adapter so the metadata of the dataset is also included in `metadata.json` - the entry has the value `objects/` in the `filename` column.

Also, this issue closes #23 and I've enabled coveralls.io and added some extra badges to the README file.

--- 

These will be the badges shown once this PR is merged:

[![Travis CI](https://travis-ci.org/JiscRDSS/rdss-archivematica-channel-adapter.svg?branch=master)](https://travis-ci.org/JiscRDSS/rdss-archivematica-channel-adapter) [![GoDoc](https://godoc.org/github.com/JiscRDSS/rdss-archivematica-channel-adapter?status.svg)](https://godoc.org/github.com/JiscRDSS/rdss-archivematica-channel-adapter) [![Coverage Status](https://coveralls.io/repos/github/JiscRDSS/rdss-archivematica-channel-adapter/badge.svg?branch=master)](https://coveralls.io/github/JiscRDSS/rdss-archivematica-channel-adapter?branch=master) [![Go Report Card](https://goreportcard.com/badge/JiscRDSS/rdss-archivematica-channel-adapter)](https://goreportcard.com/report/JiscRDSS/rdss-archivematica-channel-adapter) [![Sourcegraph](https://sourcegraph.com/github.com/JiscRDSS/rdss-archivematica-channel-adapter/-/badge.svg)](https://sourcegraph.com/github.com/JiscRDSS/rdss-archivematica-channel-adapter?badge)