### PR TITLE
Multi-stage Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,16 @@
-FROM golang:1.8.1-alpine
-
-# This Dockerfile is less useful in production environments!
-# One specific to production should be created.
-
-ARG APP_PATH=github.com/JiscRDSS/rdss-archivematica-channel-adapter
-
-RUN addgroup -g 333 -S archivematica && adduser -u 333 -S -G archivematica archivematica
-
-ADD ./ /go/src/$APP_PATH
-
-WORKDIR /go/src/$APP_PATH
-
+FROM golang:1.8.3-alpine as builder
+WORKDIR /go/src/github.com/JiscRDSS/rdss-archivematica-channel-adapter
+COPY . .
 RUN set -x \
 	&& apk add --no-cache --virtual .build-deps make gcc musl-dev \
-	&& make \
+	&& make test vet \
 	&& make build
-	# Sometimes useful during development
-	# && apk del .build-deps
 
+FROM alpine:3.6
+WORKDIR /var/lib/archivematica
+COPY --from=builder /go/src/github.com/JiscRDSS/rdss-archivematica-channel-adapter/rdss-archivematica-channel-adapter .
+RUN apk --no-cache add ca-certificates
+RUN addgroup -g 333 -S archivematica && adduser -u 333 -h /var/lib/archivematica -S -G archivematica archivematica
 USER archivematica
-
-ENTRYPOINT ["/go/bin/rdss-archivematica-channel-adapter"]
-
+ENTRYPOINT ["/var/lib/archivematica/rdss-archivematica-channel-adapter"]
 CMD ["help"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,11 @@
+FROM golang:1.8.3-alpine
+WORKDIR /go/src/github.com/JiscRDSS/rdss-archivematica-channel-adapter
+COPY . .
+RUN set -x \
+	&& apk add --no-cache --virtual .build-deps make gcc musl-dev \
+	&& make test vet \
+	&& make install
+RUN addgroup -g 333 -S archivematica && adduser -u 333 -h /var/lib/archivematica -S -G archivematica archivematica
+USER archivematica
+ENTRYPOINT ["/go/bin/rdss-archivematica-channel-adapter"]
+CMD ["help"]

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ tools:
 	go get -u github.com/golang/protobuf/protoc-gen-go
 
 build:
+	@env CGO_ENABLED=0 go build -a -o rdss-archivematica-channel-adapter .
+
+install:
 	@env CGO_ENABLED=0 go install $(PKGS)
 
 test:


### PR DESCRIPTION
Added a new multi-stage `/Dockefile` that only uses 26.8MB. The old Dockerfile
can be found at `/Dockerfile.dev` (499MB) which is still the recommended option
if you are a developer.