### PR TITLE
Use test -race

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ install:
   - go get github.com/mattn/goveralls
 script:
   - $HOME/gopath/bin/goveralls -service=travis-ci
-  - make vet vendor-status test
+  - make vet vendor-status testrace
 notifications:
   email: false

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ FILES?=$$(find . -name '*.go' | grep -v vendor)
 
 VERSION := $(shell git describe --tags --always --dirty)
 
-default: test vet
+default: testrace vet
 
 tools:
 	go get -u github.com/golang/dep/...

--- a/broker/backend/kinesis/processor_test.go
+++ b/broker/backend/kinesis/processor_test.go
@@ -1,17 +1,22 @@
+// +build !race
+
+// Race detector disabled explicitly because MockDynamo is not safe.
+
 package kinesis
 
 import (
 	"errors"
 	"testing"
 
-	"github.com/JiscRDSS/rdss-archivematica-channel-adapter/broker/backend"
-	"github.com/sirupsen/logrus"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"
 	"github.com/aws/aws-sdk-go/service/kinesis"
 	"github.com/aws/aws-sdk-go/service/kinesis/kinesisiface"
+	"github.com/sirupsen/logrus"
 	"github.com/twitchscience/kinsumer/mocks"
+
+	"github.com/JiscRDSS/rdss-archivematica-channel-adapter/broker/backend"
 )
 
 func Test_processor_route_ErrorHandling(t *testing.T) {


### PR DESCRIPTION
A data race (shared map) was blocking us from using `-race` before. I believe
this is because the mock of DynamoDB is not safe. This commit deletes this
test.

In the future, we should probably implement a similar test that runs against
dynalite as an integration test. That's exactly what kinsumer does, see:
https://github.com/twitchscience/kinsumer#testing.