### PR TITLE
Consumer: name files after fileName attr

### DIFF
--- a/consumer/consumer_unit_test.go
+++ b/consumer/consumer_unit_test.go
@@ -41,22 +41,6 @@ func Test_handleMetadataCreateRequest_emptyFiles(t *testing.T) {
 	}
 }
 
-func Test_getFilename(t *testing.T) {
-	tests := []struct {
-		path string
-		want string
-	}{
-		{"https://foo12345.com/foobar.jpg", "foobar.jpg"},
-		{"https://foo12345.com/foo/bar/rrr", "foo/bar/rrr"},
-		{":invalid-url:", ""},
-	}
-	for _, tt := range tests {
-		if got := getFilename(tt.path); tt.want != got {
-			t.Errorf("getFilename(); want %v, got %v", tt.want, got)
-		}
-	}
-}
-
 func Test_describeDataset(t *testing.T) {
 	var (
 		ts   = getTransferSession(t)


### PR DESCRIPTION
This closes #56.

I tried to write a test for it but `amclient` needs some refactoring: `TransferSession` should be an interface so I can have the `MetadataCreate` handler use a mock instead. Also the method that returns the struct isn't part of the `TransferService` interface but just coming straight from `amclient.Client`.

Solving the actual problem is a higher priority. I'll file an issue for the missing test.