### PR TITLE
Problem: Dockerfile.multi-stage doesn't install git

### DIFF
--- a/Dockerfile.multi-stage
+++ b/Dockerfile.multi-stage
@@ -3,7 +3,7 @@ WORKDIR /go/src/github.com/JiscRDSS/rdss-archivematica-channel-adapter
 COPY . .
 # Don't use `make testrace`, it won't work in Alpine Linux!
 RUN set -x \
-	&& apk add --no-cache --virtual .build-deps make gcc musl-dev \
+	&& apk add --no-cache --virtual .build-deps make gcc musl-dev git \
 	&& make test vet \
 	&& make build
 


### PR DESCRIPTION
We don't currently use the multi-stage Docker build but it's still there for when we can use it (AWS still running old version of Docker). I tested it for other reasons and I realized that it was missing the git tool which is required during the build.

This commit updates the file so git is installed at the build stage.

It's low priority.