### PR TITLE
Add gofmt support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ FILES?=$$(find . -name '*.go' | grep -v vendor)
 
 VERSION := $(shell git describe --tags --always --dirty)
 
-default: testrace vet
+default: testrace vet fmtcheck
 
 tools:
 	go get -u github.com/golang/dep/cmd/...
@@ -37,6 +37,12 @@ vet:
 		echo "and fix them if necessary before submitting the code for review."; \
 		exit 1; \
 	fi
+
+fmt:
+	gofmt -w $(FILES)
+
+fmtcheck:
+	@sh -c "'$(CURDIR)/hack/gofmtcheck.sh'"
 
 cover:
 	@hack/coverage.sh

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -21,7 +21,6 @@ func init() {
 	RootCmd.AddCommand(versionCmd)
 }
 
-
 func printVersion() {
 	fmt.Println(version.VERSION)
 }

--- a/hack/gofmtcheck.sh
+++ b/hack/gofmtcheck.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# Check gofmt
+echo "==> Checking that code complies with gofmt requirements..."
+gofmt_files=$(gofmt -l `find . -name '*.go' | grep -v vendor`)
+if [[ -n ${gofmt_files} ]]; then
+    echo 'gofmt needs running on the following files:'
+    echo "${gofmt_files}"
+    echo "You can use the command: \`make fmt\` to reformat code."
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
I've realized that we're not checking fmt errors. This commit makes the needed
changes so this happens when we run `make` which is also used by Travis CI.

The user can also run the following commands manually:

- `make gofmt` to fix fmt errors
- `make gofmtcheck` to detect fmt errors (via exit codes)

This closes #65.

---

@philgray-ark: this should be merged before #63 because that PR brings some formatting issues. #63 will need to be rebased.