### PR TITLE
broker/message: enforce use of UUIDs

### DIFF
--- a/broker/message/headers.go
+++ b/broker/message/headers.go
@@ -10,7 +10,7 @@ import (
 // including the type of Message, routing information, timings, sequencing, and
 // so forth.
 type MessageHeader struct {
-	ID              string          `json:"messageId"`
+	ID              *UUID           `json:"messageId"`
 	CorrelationID   string          `json:"correlationId,omitempty"`
 	MessageClass    MessageClass    `json:"messageClass"`
 	MessageType     MessageType     `json:"messageType"`
@@ -147,9 +147,9 @@ type MessageTimings struct {
 }
 
 type MessageSequence struct {
-	Sequence string `json:"sequence"`
-	Position int    `json:"position"`
-	Total    int    `json:"total"`
+	Sequence *UUID `json:"sequence"`
+	Position int   `json:"position"`
+	Total    int   `json:"total"`
 }
 
 type MessageHistory struct {

--- a/broker/message/message.go
+++ b/broker/message/message.go
@@ -5,8 +5,6 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/twinj/uuid"
-
 	bErrors "github.com/JiscRDSS/rdss-archivematica-channel-adapter/broker/errors"
 )
 
@@ -29,7 +27,7 @@ type Message struct {
 func New(t MessageType, c MessageClass) *Message {
 	return &Message{
 		MessageHeader: MessageHeader{
-			ID:           uuid.NewV4().String(),
+			ID:           NewUUID(),
 			MessageType:  t,
 			MessageClass: c,
 			Version:      Version,
@@ -47,7 +45,7 @@ type messageAlias struct {
 }
 
 func (m *Message) ID() string {
-	return m.MessageHeader.ID
+	return m.MessageHeader.ID.String()
 }
 
 func (m Message) Type() string {

--- a/broker/message/message_metadata.go
+++ b/broker/message/message_metadata.go
@@ -24,7 +24,7 @@ func (m Message) MetadataCreateRequest() (*MetadataCreateRequest, error) {
 
 // MetadataReadRequest represents the body of the message.
 type MetadataReadRequest struct {
-	ObjectUuid string `json:"objectUuid"`
+	ObjectUuid *UUID `json:"objectUuid"`
 }
 
 // MetadataReadRequest returns the body of the message.
@@ -70,7 +70,7 @@ func (m Message) MetadataUpdateRequest() (*MetadataUpdateRequest, error) {
 
 // MetadataDeleteRequest represents the body of the message.
 type MetadataDeleteRequest struct {
-	ObjectUuid string `json:"objectUuid"`
+	ObjectUuid *UUID `json:"objectUuid"`
 }
 
 // MetadataDeleteRequest returns the body of the message.

--- a/broker/message/message_test.go
+++ b/broker/message/message_test.go
@@ -19,7 +19,7 @@ import (
 const (
 	metadataCreateRequest = `{
   "messageHeader": {
-    "messageId": "e4bdaea0-4712-4682-8d4b-e6d92b1fe1ac",
+    "messageId": "4e5bef43-21b1-4ef4-b850-dbae05b4882d",
     "messageClass": "Command",
     "messageType": "MetadataCreate",
     "messageTimings": {
@@ -27,7 +27,7 @@ const (
       "expirationTimestamp": null
     },
     "messageSequence": {
-      "sequence": "",
+      "sequence": "6ad8194d-d1d0-4389-a64d-c73d761463c9",
       "position": 0,
       "total": 0
     },
@@ -39,12 +39,12 @@ const (
     "version": "1.3.0"
   },
   "messageBody": {
-    "objectUuid": "06f75186-f9cb-4be3-8df7-64dd037eb54f",
+    "objectUuid": "be8eff14-a92b-429e-80b8-0ec4594d72c0",
     "objectTitle": "Non-uniform Mesh for Embroidered Microstrip Antennas - Simulation files",
     "objectPersonRole": [
       {
         "person": {
-          "personUuid": "479dada4-8650-421e-8480-63d58107a998",
+          "personUuid": "8468f86b-a936-41b3-a8a7-ef37e3008ba8",
           "personIdentifier": null,
           "personEntitlement": null,
           "personOrganisation": null,
@@ -78,7 +78,7 @@ const (
     ],
     "objectFile": [
       {
-        "fileUuid": "42143745-dba9-9c98-cdd7-0c521ae55118",
+        "fileUuid": "f8351e4f-66cc-4434-b0f1-54e7038c031a",
         "fileIdentifier": "1",
         "fileName": "woodpigeon-pic.jpg",
         "fileSize": 147004,
@@ -112,7 +112,7 @@ const (
         "fileStorageType": 1
       },
       {
-        "fileUuid": "9102f719-2f78-d9c2-de12-15f27024f78b",
+        "fileUuid": "c23d70ee-cc6b-4698-8d4c-9dcaefb40672",
         "fileIdentifier": "2",
         "fileName": "bird-sounds.mp3",
         "fileSize": 910616,
@@ -198,7 +198,7 @@ func TestMessage_ToJSON(t *testing.T) {
 			[]byte(metadataCreateRequest),
 			&Message{
 				MessageHeader: MessageHeader{
-					ID:           "e4bdaea0-4712-4682-8d4b-e6d92b1fe1ac",
+					ID:           MustUUID("4e5bef43-21b1-4ef4-b850-dbae05b4882d"),
 					MessageClass: MessageClassCommand,
 					MessageType:  MessageTypeMetadataCreate,
 					MessageHistory: MessageHistory{
@@ -206,16 +206,21 @@ func TestMessage_ToJSON(t *testing.T) {
 						MachineAddress: "bar",
 						Timestamp:      Timestamp(time.Date(1997, time.July, 16, 19, 20, 0, 0, time.FixedZone("+0100", 3600))),
 					},
+					MessageSequence: MessageSequence{
+						Sequence: MustUUID("6ad8194d-d1d0-4389-a64d-c73d761463c9"),
+						Position: 0,
+						Total:    0,
+					},
 					Version: Version,
 				},
 				MessageBody: &MetadataCreateRequest{
 					ResearchObject{
-						ObjectUuid:  "06f75186-f9cb-4be3-8df7-64dd037eb54f",
+						ObjectUuid:  MustUUID("be8eff14-a92b-429e-80b8-0ec4594d72c0"),
 						ObjectTitle: "Non-uniform Mesh for Embroidered Microstrip Antennas - Simulation files",
 						ObjectPersonRole: []PersonRole{
 							{
 								Person: &Person{
-									PersonUuid:      "479dada4-8650-421e-8480-63d58107a998",
+									PersonUuid:      MustUUID("8468f86b-a936-41b3-a8a7-ef37e3008ba8"),
 									PersonGivenName: "Zhang, Shiyu",
 								},
 								Role: PersonRoleEnum_dataCreator,
@@ -238,7 +243,7 @@ func TestMessage_ToJSON(t *testing.T) {
 						},
 						ObjectFile: []File{
 							{
-								FileUUID:       "42143745-dba9-9c98-cdd7-0c521ae55118",
+								FileUUID:       MustUUID("f8351e4f-66cc-4434-b0f1-54e7038c031a"),
 								FileIdentifier: "1",
 								FileName:       "woodpigeon-pic.jpg",
 								FileSize:       147004,
@@ -252,7 +257,7 @@ func TestMessage_ToJSON(t *testing.T) {
 								FileStorageType:     1,
 							},
 							{
-								FileUUID:       "9102f719-2f78-d9c2-de12-15f27024f78b",
+								FileUUID:       MustUUID("c23d70ee-cc6b-4698-8d4c-9dcaefb40672"),
 								FileIdentifier: "2",
 								FileName:       "bird-sounds.mp3",
 								FileSize:       910616,
@@ -310,11 +315,11 @@ func TestMessage_New(t *testing.T) {
 
 func TestMessage_ID(t *testing.T) {
 	m := &Message{
-		MessageHeader: MessageHeader{ID: "ID"},
+		MessageHeader: MessageHeader{ID: NewUUID()},
 		MessageBody:   typedBody(MessageTypeVocabularyRead, ""),
 	}
-	if id := m.ID(); id != "ID" {
-		t.Errorf("unexpected ID: %v", id)
+	if have, want := m.ID(), m.MessageHeader.ID.String(); have != want {
+		t.Errorf("Unexpected ID; have %v, want %v", have, want)
 	}
 }
 

--- a/broker/message/schema_intelectual_asset.go
+++ b/broker/message/schema_intelectual_asset.go
@@ -1,7 +1,7 @@
 package message
 
 type File struct {
-	FileUUID                string              `json:"fileUuid"`
+	FileUUID                *UUID               `json:"fileUuid"`
 	FileIdentifier          string              `json:"fileIdentifier"`
 	FileName                string              `json:"fileName"`
 	FileSize                int                 `json:"fileSize"`
@@ -25,7 +25,7 @@ type File struct {
 }
 
 type Checksum struct {
-	ChecksumUuid  string           `json:"checksumUuid,omitempty"`
+	ChecksumUuid  *UUID            `json:"checksumUuid,omitempty"`
 	ChecksumType  ChecksumTypeEnum `json:"checksumType"`
 	ChecksumValue string           `json:"checksumValue"`
 }
@@ -49,7 +49,7 @@ type FilePermission struct {
 }
 
 type Group struct {
-	GroupUuid           string           `json:"groupUuid"`
+	GroupUuid           *UUID            `json:"groupUuid"`
 	GroupName           string           `json:"groupName"`
 	GroupIdentifier     string           `json:"groupIdentifier"`
 	GroupFilePermission []FilePermission `json:"groupFilePermission"`
@@ -57,7 +57,7 @@ type Group struct {
 }
 
 type Grant struct {
-	GrantUuid       string           `json:"grantUuid"`
+	GrantUuid       *UUID            `json:"grantUuid"`
 	GrantIdentifier string           `json:"grantIdentifier"`
 	GrantFunder     OrganisationRole `json:"grantFunder"`
 	GrantStart      Date             `json:"grantStart"`
@@ -66,7 +66,7 @@ type Grant struct {
 }
 
 type Project struct {
-	ProjectUuid        string       `json:"projectUuid"`
+	ProjectUuid        *UUID        `json:"projectUuid"`
 	ProjectIdentifier  []string     `json:"projectIdentifier"`
 	ProjectName        string       `json:"projectName"`
 	ProjectDescription string       `json:"projectDescription"`

--- a/broker/message/schema_material_asset.go
+++ b/broker/message/schema_material_asset.go
@@ -8,7 +8,7 @@ type Organisation struct {
 }
 
 type Person struct {
-	PersonUuid            string                           `json:"personUuid"`
+	PersonUuid            *UUID                            `json:"personUuid"`
 	PersonIdentifier      []PersonIdentifier               `json:"personIdentifier"`
 	PersonEntitlement     []PersonRoleEnum                 `json:"personEntitlement"`
 	PersonOrganisation    []Organisation                   `json:"personOrganisation"`

--- a/broker/message/schema_research_object.go
+++ b/broker/message/schema_research_object.go
@@ -1,7 +1,7 @@
 package message
 
 type ResearchObject struct {
-	ObjectUuid              string              `json:"objectUuid"`
+	ObjectUuid              *UUID               `json:"objectUuid"`
 	ObjectTitle             string              `json:"objectTitle"`
 	ObjectPersonRole        []PersonRole        `json:"objectPersonRole"`
 	ObjectDescription       string              `json:"objectDescription"`
@@ -52,7 +52,7 @@ type Identifier struct {
 }
 
 type Collection struct {
-	CollectionUuid              string             `json:"collectionUuid"`
+	CollectionUuid              *UUID              `json:"collectionUuid"`
 	CollectionName              string             `json:"collectionName"`
 	CollectionObject            []ResearchObject   `json:"collectionObject,omitempty"`
 	CollectionKeywords          []string           `json:"collectionKeywords,omitempty"`

--- a/broker/message/uuid.go
+++ b/broker/message/uuid.go
@@ -1,0 +1,53 @@
+package message
+
+import (
+	"encoding/json"
+
+	"github.com/twinj/uuid"
+)
+
+type UUID struct {
+	sub uuid.UUID
+}
+
+func NewUUID() *UUID {
+	return &UUID{sub: uuid.NewV4()}
+}
+
+func ParseUUID(str string) (*UUID, error) {
+	ret, err := uuid.Parse(str)
+	if err != nil {
+		return nil, err
+	}
+	return &UUID{sub: *ret}, nil
+}
+
+func MustUUID(str string) *UUID {
+	ret, err := ParseUUID(str)
+	if err != nil {
+		panic(err)
+	}
+	return ret
+}
+
+func (u UUID) String() string {
+	return u.sub.String()
+}
+
+func (u UUID) MarshalJSON() ([]byte, error) {
+	return json.Marshal(u.sub.String())
+}
+
+func (u *UUID) UnmarshalJSON(data []byte) error {
+	var str string
+	err := json.Unmarshal(data, &str)
+	if err != nil {
+		return err
+	}
+	id, err := uuid.Parse(str)
+	if err != nil {
+		return err
+	}
+	u.sub = *id
+	return nil
+}

--- a/broker/message/uuid_test.go
+++ b/broker/message/uuid_test.go
@@ -31,7 +31,7 @@ func TestMustUUIDWithPanic(t *testing.T) {
 	})
 	t.Run("WithoutPanic", func(t *testing.T) {
 		defer func() {
-			if r := recover(); r == nil {
+			if r := recover(); r != nil {
 				t.Error("The code did panic")
 			}
 		}()

--- a/broker/message/uuid_test.go
+++ b/broker/message/uuid_test.go
@@ -1,0 +1,89 @@
+package message
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+const (
+	validUUID   = "be8eff14-a92b-429e-80b8-0ec4594d72c0"
+	invalidUUID = "--invalid-uuid--"
+)
+
+func TestParseUUID(t *testing.T) {
+	if _, err := ParseUUID(validUUID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ParseUUID(invalidUUID); err == nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMustUUIDWithPanic(t *testing.T) {
+	t.Run("WithPanic", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Error("The code did not panic")
+			}
+		}()
+		MustUUID(invalidUUID)
+	})
+	t.Run("WithoutPanic", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Error("The code did panic")
+			}
+		}()
+		MustUUID(validUUID)
+	})
+}
+
+func TestMarshalJSON(t *testing.T) {
+	in := NewUUID()
+	have, err := json.Marshal(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const quote = byte(rune('"'))
+	want := []byte(in.String())
+	want = append([]byte{quote}, want...)
+	want = append(want, quote)
+
+	if !bytes.Equal(have, want) {
+		t.Fatalf("Unexpected result, have %v, want %v", have, want)
+	}
+}
+
+func TestUnmarshalJSON(t *testing.T) {
+	testCases := []struct {
+		name       string
+		uuid       string
+		shouldFail bool
+	}{
+		{"Valid UUID", validUUID, false},
+		{"Invalid UUID", invalidUUID, true},
+		{"Invalid JSON", `", "`, true},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var (
+				encoded = []byte(`"` + tc.uuid + `"`)
+				id      = &UUID{}
+			)
+			err := json.Unmarshal(encoded, id)
+			if tc.shouldFail && err == nil {
+				t.Fatal("Decoding did not fail.")
+			} else if !tc.shouldFail && err != nil {
+				t.Fatalf("Decoding failed: %v", err)
+			}
+			if tc.shouldFail {
+				return
+			}
+			if have, want := id.String(), tc.uuid; have != want {
+				t.Fatalf("Unexpected output; have %s, want %s.", have, want)
+			}
+		})
+	}
+}

--- a/broker/repository.go
+++ b/broker/repository.go
@@ -4,12 +4,13 @@ import (
 	"errors"
 	"sync"
 
-	"github.com/JiscRDSS/rdss-archivematica-channel-adapter/broker/message"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"
+
+	"github.com/JiscRDSS/rdss-archivematica-channel-adapter/broker/message"
 )
 
 var ErrInvalidRepositoryConfig = errors.New("invalid repository configuration")

--- a/broker/repository_test.go
+++ b/broker/repository_test.go
@@ -101,8 +101,8 @@ func Test_toRepoMessage(t *testing.T) {
 	}{
 		{nil, nil, true},
 		{
-			&message.Message{MessageHeader: message.MessageHeader{ID: "foobar"}},
-			&RepositoryMessage{MessageId: "foobar"},
+			&message.Message{MessageHeader: message.MessageHeader{ID: message.MustUUID("ab0f8186-4b68-430e-a07e-b517300e6f9f")}},
+			&RepositoryMessage{MessageId: "ab0f8186-4b68-430e-a07e-b517300e6f9f"},
 			false,
 		},
 	}
@@ -163,16 +163,16 @@ func TestRepositoryBuiltinImpl_Put(t *testing.T) {
 		errWanted bool
 	}{
 		{
-			"12345",
-			&message.Message{MessageHeader: message.MessageHeader{ID: "12345"}},
-			"12345",
+			"ab0f8186-4b68-430e-a07e-b517300e6f9f",
+			&message.Message{MessageHeader: message.MessageHeader{ID: message.MustUUID("ab0f8186-4b68-430e-a07e-b517300e6f9f")}},
+			"ab0f8186-4b68-430e-a07e-b517300e6f9f",
 			true,
 			false,
 		},
 		{
 			"my-id",
-			&message.Message{MessageHeader: message.MessageHeader{ID: "12345"}},
-			"12345",
+			&message.Message{MessageHeader: message.MessageHeader{ID: message.MustUUID("ab0f8186-4b68-430e-a07e-b517300e6f9f")}},
+			"ab0f8186-4b68-430e-a07e-b517300e6f9f",
 			false,
 			false,
 		},
@@ -244,8 +244,16 @@ func TestRepositoryDynamoDBImpl_Put(t *testing.T) {
 		wantErr bool
 		client  *mockDynamoDBClient
 	}{
-		{&message.Message{}, false, &mockDynamoDBClient{}},
-		{&message.Message{}, true, &mockDynamoDBClient{PutItem_WantedErr: errors.New("error")}},
+		{
+			message.New(message.MessageTypeMetadataCreate, message.MessageClassCommand),
+			false,
+			&mockDynamoDBClient{},
+		},
+		{
+			message.New(message.MessageTypeMetadataCreate, message.MessageClassCommand),
+			true,
+			&mockDynamoDBClient{PutItem_WantedErr: errors.New("error")},
+		},
 		{nil, true, nil},
 		// TODO: check case with dynamodbattribute.MarshalMap(rMsg) returning error
 	}

--- a/consumer/consumer_test.go
+++ b/consumer/consumer_test.go
@@ -103,15 +103,15 @@ func TestValidCreateMetadataMessage(t *testing.T) {
 	msg := message.New(message.MessageTypeMetadataCreate, message.MessageClassCommand)
 	body := &message.MetadataCreateRequest{
 		ResearchObject: message.ResearchObject{
-			ObjectUuid:  "a90652dd-6abd-424c-b7ce-d6728c7f3f9f",
+			ObjectUuid:  message.MustUUID("a90652dd-6abd-424c-b7ce-d6728c7f3f9f"),
 			ObjectTitle: "Research about birds in Doñana National Park",
 			ObjectFile: []message.File{
 				message.File{
-					FileUUID:            "One",
+					FileUUID:            message.MustUUID("6129ea79-6f4e-4348-a832-ba03bd7631d8"),
 					FileStorageLocation: "s3://bucket-01/one.mp3",
 				},
 				message.File{
-					FileUUID:            "Two",
+					FileUUID:            message.MustUUID("2e1dd38d-924c-464a-a0ab-58b14712a8e8"),
 					FileStorageLocation: "s3://bucket-01/two.wav",
 				},
 			},

--- a/fixtures/messages/body/metadata/create/request.json
+++ b/fixtures/messages/body/metadata/create/request.json
@@ -1,10 +1,10 @@
 {
-  "objectUuid": "string",
+  "objectUuid": "be8eff14-a92b-429e-80b8-0ec4594d72c0",
   "objectTitle": "string",
   "objectPersonRole": [
     {
       "person": {
-        "personUuid": "string",
+        "personUuid": "be8eff14-a92b-429e-80b8-0ec4594d72c0",
         "personIdentifier": [
           {
             "personIdentifierValue": "string",
@@ -106,7 +106,7 @@
   ],
   "objectFile": [
     {
-      "fileUuid": "string",
+      "fileUuid": "be8eff14-a92b-429e-80b8-0ec4594d72c0",
       "fileIdentifier": "string",
       "fileName": "string",
       "fileSize": 1,
@@ -137,7 +137,7 @@
       },
       "fileChecksum": [
         {
-          "checksumUuid": "string",
+          "checksumUuid": "be8eff14-a92b-429e-80b8-0ec4594d72c0",
           "checksumType": 1,
           "checksumValue": "string"
         }

--- a/fixtures/messages/body/metadata/delete/request.json
+++ b/fixtures/messages/body/metadata/delete/request.json
@@ -1,3 +1,3 @@
 {
-  "objectUuid": "string"
+  "objectUuid": "be8eff14-a92b-429e-80b8-0ec4594d72c0"
 }

--- a/fixtures/messages/body/metadata/read/request.json
+++ b/fixtures/messages/body/metadata/read/request.json
@@ -1,3 +1,3 @@
 {
-  "objectUuid": "string"
+  "objectUuid": "be8eff14-a92b-429e-80b8-0ec4594d72c0"
 }

--- a/fixtures/messages/body/metadata/read/response.json
+++ b/fixtures/messages/body/metadata/read/response.json
@@ -1,10 +1,10 @@
 {
-  "objectUuid": "string",
+  "objectUuid": "be8eff14-a92b-429e-80b8-0ec4594d72c0",
   "objectTitle": "string",
   "objectPersonRole": [
     {
       "person": {
-        "personUuid": "string",
+        "personUuid": "be8eff14-a92b-429e-80b8-0ec4594d72c0",
         "personIdentifier": [
           {
             "personIdentifierValue": "string",
@@ -106,7 +106,7 @@
   ],
   "objectFile": [
     {
-      "fileUuid": "string",
+      "fileUuid": "be8eff14-a92b-429e-80b8-0ec4594d72c0",
       "fileIdentifier": "string",
       "fileName": "string",
       "fileSize": 1,
@@ -137,7 +137,7 @@
       },
       "fileChecksum": [
         {
-          "checksumUuid": "string",
+          "checksumUuid": "be8eff14-a92b-429e-80b8-0ec4594d72c0",
           "checksumType": 1,
           "checksumValue": "string"
         }

--- a/fixtures/messages/body/metadata/update/request.json
+++ b/fixtures/messages/body/metadata/update/request.json
@@ -1,10 +1,10 @@
 {
-  "objectUuid": "string",
+  "objectUuid": "be8eff14-a92b-429e-80b8-0ec4594d72c0",
   "objectTitle": "string",
   "objectPersonRole": [
     {
       "person": {
-        "personUuid": "string",
+        "personUuid": "be8eff14-a92b-429e-80b8-0ec4594d72c0",
         "personIdentifier": [
           {
             "personIdentifierValue": "string",
@@ -106,7 +106,7 @@
   ],
   "objectFile": [
     {
-      "fileUuid": "string",
+      "fileUuid": "be8eff14-a92b-429e-80b8-0ec4594d72c0",
       "fileIdentifier": "string",
       "fileName": "string",
       "fileSize": 1,
@@ -137,7 +137,7 @@
       },
       "fileChecksum": [
         {
-          "checksumUuid": "string",
+          "checksumUuid": "be8eff14-a92b-429e-80b8-0ec4594d72c0",
           "checksumType": 1,
           "checksumValue": "string"
         }

--- a/fixtures/messages/example.json
+++ b/fixtures/messages/example.json
@@ -10,7 +10,7 @@
       "expirationTimestamp": ""
     },
     "messageSequence": {
-      "sequence": "string",
+      "sequence": "6ad8194d-d1d0-4389-a64d-c73d761463c9",
       "position": 1,
       "total": 1
     },

--- a/fixtures/messages/header/example.json
+++ b/fixtures/messages/header/example.json
@@ -1,5 +1,5 @@
 {
-  "messageId": "string",
+  "messageId": "bfe69843-cc7f-40f1-a3a8-eee126ee5f23",
   "correlationId": "string",
   "messageClass": "Command",
   "messageType": "MetadataCreate",
@@ -9,7 +9,7 @@
     "expirationTimestamp": ""
   },
   "messageSequence": {
-    "sequence": "string",
+    "sequence": "6ad8194d-d1d0-4389-a64d-c73d761463c9",
     "position": 1,
     "total": 1
   },


### PR DESCRIPTION
[RDSSARK-371](https://jiscdev.atlassian.net/browse/RDSSARK-371).

Add custom `UUID` type used for JSON encoding/decoding. Use it in the fields where the message API specifies that the type is UUID, e.g.: `messageId` or in a variety or fields in the message payloads.