### PR TITLE
broker/message: validate fixtures

### DIFF
--- a/fixtures/messages/body/metadata/create/request.json
+++ b/fixtures/messages/body/metadata/create/request.json
@@ -60,7 +60,7 @@
   ],
   "objectDate": [
     {
-      "dateValue": "string",
+      "dateValue": "2002-10-02T10:00:00-05:00",
       "dateType": 1
     }
   ],
@@ -112,7 +112,7 @@
       "fileSize": 1,
       "fileLabel": "string",
       "fileDateCreated": {
-        "dateValue": "string",
+        "dateValue": "2002-10-02T10:00:00-05:00",
         "dateType": 1
       },
       "fileRights": {
@@ -147,7 +147,7 @@
       "fileHasMimeType": true,
       "fileDateModified": [
         {
-          "dateValue": "string",
+          "dateValue": "2002-10-02T10:00:00-05:00",
           "dateType": 1
         }
       ],
@@ -164,14 +164,14 @@
       ],
       "fileUploadStatus": 1,
       "fileStorageStatus": 1,
-      "fileLastDownload": {
-        "dateValue": "string",
+      "fileLastDownloaded": {
+        "dateValue": "2002-10-02T10:00:00-05:00",
         "dateType": 1
       },
       "fileTechnicalAttributes": [
         "string"
       ],
-      "fileStorageLocation": "string",
+      "fileStorageLocation": "https://tools.ietf.org/html/rfc3986",
       "fileStorageType": 1
     }
   ]

--- a/fixtures/messages/body/metadata/update/request.json
+++ b/fixtures/messages/body/metadata/update/request.json
@@ -60,7 +60,7 @@
   ],
   "objectDate": [
     {
-      "dateValue": "string",
+      "dateValue": "2002-10-02T10:00:00-05:00",
       "dateType": 1
     }
   ],
@@ -112,7 +112,7 @@
       "fileSize": 1,
       "fileLabel": "string",
       "fileDateCreated": {
-        "dateValue": "string",
+        "dateValue": "2002-10-02T10:00:00-05:00",
         "dateType": 1
       },
       "fileRights": {
@@ -147,7 +147,7 @@
       "fileHasMimeType": true,
       "fileDateModified": [
         {
-          "dateValue": "string",
+          "dateValue": "2002-10-02T10:00:00-05:00",
           "dateType": 1
         }
       ],
@@ -164,14 +164,14 @@
       ],
       "fileUploadStatus": 1,
       "fileStorageStatus": 1,
-      "fileLastDownload": {
-        "dateValue": "string",
+      "fileLastDownloaded": {
+        "dateValue": "2002-10-02T10:00:00-05:00",
         "dateType": 1
       },
       "fileTechnicalAttributes": [
         "string"
       ],
-      "fileStorageLocation": "string",
+      "fileStorageLocation": "https://tools.ietf.org/html/rfc3986",
       "fileStorageType": 1
     }
   ]

--- a/fixtures/messages/example.json
+++ b/fixtures/messages/example.json
@@ -14,11 +14,13 @@
       "position": 1,
       "total": 1
     },
-    "messageHistory": {
-      "machineId": "string",
-      "machineAddress": "string",
-      "timestamp": ""
-    },
+    "messageHistory": [
+      {
+        "machineId": "string",
+        "machineAddress": "string",
+        "timestamp": ""
+      }
+    ],
     "version": "",
     "errorCode": "GENERR001",
     "errorDescription": "string"
@@ -85,7 +87,7 @@
     ],
     "objectDate": [
       {
-        "dateValue": "string",
+        "dateValue": "2002-10-02T10:00:00-05:00",
         "dateType": 1
       }
     ],
@@ -137,7 +139,7 @@
         "fileSize": 1,
         "fileLabel": "string",
         "fileDateCreated": {
-          "dateValue": "string",
+          "dateValue": "2002-10-02T10:00:00-05:00",
           "dateType": 1
         },
         "fileRights": {
@@ -172,7 +174,7 @@
         "fileHasMimeType": true,
         "fileDateModified": [
           {
-            "dateValue": "string",
+            "dateValue": "2002-10-02T10:00:00-05:00",
             "dateType": 1
           }
         ],
@@ -189,8 +191,8 @@
         ],
         "fileUploadStatus": 1,
         "fileStorageStatus": 1,
-        "fileLastDownload": {
-          "dateValue": "string",
+        "fileLastDownloaded": {
+          "dateValue": "2002-10-02T10:00:00-05:00",
           "dateType": 1
         },
         "fileTechnicalAttributes": [

--- a/hack/README.md
+++ b/hack/README.md
@@ -21,3 +21,26 @@ By default gRPC uses protocol buffers. You will need the `protoc` compiler to
 generate stub server and client code, which is listed as a development
 dependency above. Use the [build-proto.sh](build-proto.sh) script to do it
 automatically.
+
+## Download the schema files
+
+The schema files can be downloaded with the following command:
+
+    $ ./download-schemas.sh $GH_API_TOKEN
+
+You have to create your own
+[personal API token](https://github.com/settings/tokens).
+
+## Running tests
+
+Use Go 1.9 or newer.
+
+Run the following command in the root directory:
+
+    $ go test -race ./...
+
+Also from the root directory you can run the validator tests against the
+fixtures as long as you have already [downloaded the schema files](#download-the-schema-files).
+This is the command that you need to run from the root directory:
+
+    $ go test ./broker/message -validator.enabled=true -validator.schemasDir=$PWD/hack/schemas


### PR DESCRIPTION
I figured it would be nice to have the validator optionally testing the fixtures. I've added some notes to `hack/README.md` on how to run these tests as they're special in that they need the schema files to be previously downloaded by the developer.
  