### PR TITLE
broker/message: treat MessageHistory as array

### DIFF
--- a/broker/message/headers.go
+++ b/broker/message/headers.go
@@ -10,23 +10,17 @@ import (
 // including the type of Message, routing information, timings, sequencing, and
 // so forth.
 type MessageHeader struct {
-	ID              *UUID           `json:"messageId"`
-	CorrelationID   string          `json:"correlationId,omitempty"`
-	MessageClass    MessageClass    `json:"messageClass"`
-	MessageType     MessageType     `json:"messageType"`
-	ReturnAddress   string          `json:"returnAddress,omitempty"`
-	MessageTimings  MessageTimings  `json:"messageTimings"`
-	MessageSequence MessageSequence `json:"messageSequence"`
-	// The multiplicity of `messageHistory` based on the spec is `0..*` but the
-	// message examples seen used `object` instead of `array` to encode
-	// single-item lists. We're going to use `MessageHistory` instead of
-	// `[]MessageHistory` until this is clarified but we will not be able to
-	// decode the message when `array` is used. We could support both types by
-	// if we make `MessageHistory` implement `Unmarshaler`.
-	MessageHistory   MessageHistory `json:"messageHistory,omitempty"`
-	Version          string         `json:"version"`
-	ErrorCode        string         `json:"errorCode,omitempty"`
-	ErrorDescription string         `json:"errorDescription,omitempty"`
+	ID               *UUID            `json:"messageId"`
+	CorrelationID    string           `json:"correlationId,omitempty"`
+	MessageClass     MessageClass     `json:"messageClass"`
+	MessageType      MessageType      `json:"messageType"`
+	ReturnAddress    string           `json:"returnAddress,omitempty"`
+	MessageTimings   MessageTimings   `json:"messageTimings"`
+	MessageSequence  MessageSequence  `json:"messageSequence"`
+	MessageHistory   []MessageHistory `json:"messageHistory,omitempty"`
+	Version          string           `json:"version"`
+	ErrorCode        string           `json:"errorCode,omitempty"`
+	ErrorDescription string           `json:"errorDescription,omitempty"`
 }
 
 // MessageClass is one of Command, Event or Document.

--- a/broker/message/message_test.go
+++ b/broker/message/message_test.go
@@ -172,7 +172,7 @@ func TestMessage_FromJSON(t *testing.T) {
 				return
 			}
 			if err != nil {
-				t.Errorf("error unmarshalling the message: %s", err)
+				t.Fatalf("error unmarshalling the message: %s", err)
 			}
 			if msg.MessageHeader.MessageType != tc.et {
 				t.Errorf("expected=%s received=%s", tc.et, msg.MessageHeader.MessageType)

--- a/broker/message/message_test.go
+++ b/broker/message/message_test.go
@@ -31,11 +31,13 @@ const (
       "position": 0,
       "total": 0
     },
-    "messageHistory": {
-      "machineId": "foo",
-      "machineAddress": "bar",
-      "timestamp": "1997-07-16T19:20:00+01:00"
-    },
+    "messageHistory": [
+      {
+        "machineId": "foo",
+        "machineAddress": "bar",
+        "timestamp": "1997-07-16T19:20:00+01:00"
+      }
+    ],
     "version": "1.3.0"
   },
   "messageBody": {
@@ -201,10 +203,12 @@ func TestMessage_ToJSON(t *testing.T) {
 					ID:           MustUUID("4e5bef43-21b1-4ef4-b850-dbae05b4882d"),
 					MessageClass: MessageClassCommand,
 					MessageType:  MessageTypeMetadataCreate,
-					MessageHistory: MessageHistory{
-						MachineId:      "foo",
-						MachineAddress: "bar",
-						Timestamp:      Timestamp(time.Date(1997, time.July, 16, 19, 20, 0, 0, time.FixedZone("+0100", 3600))),
+					MessageHistory: []MessageHistory{
+						MessageHistory{
+							MachineId:      "foo",
+							MachineAddress: "bar",
+							Timestamp:      Timestamp(time.Date(1997, time.July, 16, 19, 20, 0, 0, time.FixedZone("+0100", 3600))),
+						},
 					},
 					MessageSequence: MessageSequence{
 						Sequence: MustUUID("6ad8194d-d1d0-4389-a64d-c73d761463c9"),


### PR DESCRIPTION
This reverts a change introduced in #70 that shouldn't have been introduced in the first place.

It closes #73.