### PR TITLE
Abort transfers when downloads fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,11 +105,11 @@ When set to a non-empty string, it's combined with `S3.ACCESS_KEY` to set up the
 
 AWS Region. If empty, the AWS SDK will throw an error. E.g.: `eu-west-2`.
 
-:heavy_minus_sign: `CONSUMER.ARCHIVEMATICA_TRANSFER_DEPOSIT_DIR`
+:heavy_minus_sign: `CONSUMER.ARCHIVEMATICA_SHARED_DIR`
 
-> Default: `"/var/archivematica/sharedDirectory/watchedDirectories/activeTransfers/standardTransfer"`
+> Default: `"/var/archivematica/sharedDirectory"`
 
-Location of the `standardTransfer` directory of the Archivematica pipeline.
+Location of the Archivematica Shared Directory.
 
 :heavy_minus_sign: `PUBLISHER.LISTEN`
 

--- a/amclient/transfer_session.go
+++ b/amclient/transfer_session.go
@@ -250,6 +250,13 @@ func (s *TransferSession) Contents() []string {
 	return paths
 }
 
+// Destroy removes the transfer directory and its contents. The caller should
+// not expect TransferSession to be in a usable state once this method has been
+// called.
+func (s *TransferSession) Destroy() error {
+	return s.amSharedFs.RemoveAll(s.path())
+}
+
 // DescribeFile registers metadata of a file. It causes the transfer to include
 // a `metadata.json` file with the metadata of each file described.
 func (s *TransferSession) DescribeFile(name, field, value string) {

--- a/amclient/transfer_session_test.go
+++ b/amclient/transfer_session_test.go
@@ -237,6 +237,22 @@ func TestTransferSession_Contents(t *testing.T) {
 	}
 }
 
+func TestTransferSession_Destroy(t *testing.T) {
+	var (
+		ts   = newTransferSession(t, "")
+		path = ts.path()
+	)
+	afero.TempFile(ts.fs, "/", "uno")
+	afero.TempFile(ts.fs, "/", "dos")
+
+	if err := ts.Destroy(); err != nil {
+		t.Fatalf("TransferSession.Destroy() returned an error: %v", err)
+	}
+	if found, err := ts.amSharedFs.DirExists(path); err != nil || found {
+		t.Fatalf("TransferSession.Destroy() didn't have the expected results; err=%v, found=%t", err, found)
+	}
+}
+
 func TestTransferSession_createMetadataDir(t *testing.T) {
 	ts := newTransferSession(t, "")
 

--- a/cmd/consumer/consumer.go
+++ b/cmd/consumer/consumer.go
@@ -62,12 +62,12 @@ func start() {
 		logger.Fatalln(err)
 	}
 
-	depositDir := viper.GetString("consumer.archivematica_transfer_deposit_dir")
-	depositFs := afero.NewBasePathFs(afero.NewOsFs(), depositDir)
+	amSharedDir := viper.GetString("consumer.archivematica_shared_dir")
+	amSharedFs := afero.NewBasePathFs(afero.NewOsFs(), amSharedDir)
 
 	quit := make(chan struct{})
 	go func() {
-		c := consumer.MakeConsumer(ctx, logger, br, createAmClient(), s3Client, depositFs)
+		c := consumer.MakeConsumer(ctx, logger, br, createAmClient(), s3Client, amSharedFs)
 		c.Start()
 
 		quit <- struct{}{}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -34,7 +34,7 @@ secret_key = ""
 region = ""
 
 [consumer]
-archivematica_transfer_deposit_dir = "/var/archivematica/sharedDirectory/watchedDirectories/activeTransfers/standardTransfer"
+archivematica_shared_dir = "/var/archivematica/sharedDirectory"
 
 [publisher]
 listen = "0.0.0.0:8000"

--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -25,12 +25,12 @@ type Consumer interface {
 
 // ConsumerImpl is an implementation of Consumer.
 type ConsumerImpl struct {
-	broker    *broker.Broker
-	ctx       context.Context
-	logger    log.FieldLogger
-	amc       *amclient.Client
-	s3        s3.ObjectStorage
-	depositFs afero.Fs
+	broker     *broker.Broker
+	ctx        context.Context
+	logger     log.FieldLogger
+	amc        *amclient.Client
+	s3         s3.ObjectStorage
+	amSharedFs afero.Fs
 }
 
 // MakeConsumer returns a new ConsumerImpl which implements Consumer
@@ -40,14 +40,14 @@ func MakeConsumer(
 	broker *broker.Broker,
 	amc *amclient.Client,
 	s3 s3.ObjectStorage,
-	depositFs afero.Fs) *ConsumerImpl {
+	amSharedFs afero.Fs) *ConsumerImpl {
 	return &ConsumerImpl{
-		ctx:       ctx,
-		logger:    logger,
-		broker:    broker,
-		amc:       amc,
-		s3:        s3,
-		depositFs: depositFs,
+		ctx:        ctx,
+		logger:     logger,
+		broker:     broker,
+		amc:        amc,
+		s3:         s3,
+		amSharedFs: amSharedFs,
 	}
 }
 
@@ -73,7 +73,7 @@ func (c *ConsumerImpl) handleMetadataCreateRequest(msg *message.Message) error {
 		return nil
 	}
 
-	t, err := c.amc.TransferSession(body.ObjectTitle, c.depositFs)
+	t, err := c.amc.TransferSession(body.ObjectTitle, c.amSharedFs)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
https://jiscdev.atlassian.net/browse/RDSSARK-336

This pull request makes changes to the `MetadataCreate` message handler to abort the transfer when the download process fails.

For this to be possible, `amclient.TransferSession` now stages the transfer in the `tmp` directory of the Archivematica Shared Directory before it's moved into the `standardTransfer` watched directory.

### Backward-incompatible changes

The environment string:

```
RDSS_ARCHIVEMATICA_ADAPTER_CONSUMER.ARCHIVEMATICA_TRANSFER_DEPOSIT_DIR=/var/archivematica/sharedDirectory/watchedDirectories/activeTransfers/standardTransfer
```

... is replaced by:

```
RDSS_ARCHIVEMATICA_ADAPTER_CONSUMER.ARCHIVEMATICA_SHARED_DIR=/var/archivematica/sharedDirectory
```

This won't affect you if you have been relying on the default which is true for existing deployments of the adapter as far as I know.

---

401e4ed is just a small change in CI so coverage doesn't include the source code generated by the machine.