### PR TITLE
Add validation modes

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,42 +3,7 @@
 
 [[projects]]
   name = "github.com/aws/aws-sdk-go"
-  packages = [
-    "aws",
-    "aws/awserr",
-    "aws/awsutil",
-    "aws/client",
-    "aws/client/metadata",
-    "aws/corehandlers",
-    "aws/credentials",
-    "aws/credentials/ec2rolecreds",
-    "aws/credentials/endpointcreds",
-    "aws/credentials/stscreds",
-    "aws/defaults",
-    "aws/ec2metadata",
-    "aws/endpoints",
-    "aws/request",
-    "aws/session",
-    "aws/signer/v4",
-    "internal/shareddefaults",
-    "private/protocol",
-    "private/protocol/json/jsonutil",
-    "private/protocol/jsonrpc",
-    "private/protocol/query",
-    "private/protocol/query/queryutil",
-    "private/protocol/rest",
-    "private/protocol/restxml",
-    "private/protocol/xml/xmlutil",
-    "service/dynamodb",
-    "service/dynamodb/dynamodbattribute",
-    "service/dynamodb/dynamodbiface",
-    "service/kinesis",
-    "service/kinesis/kinesisiface",
-    "service/s3",
-    "service/s3/s3iface",
-    "service/s3/s3manager",
-    "service/sts"
-  ]
+  packages = ["aws","aws/awserr","aws/awsutil","aws/client","aws/client/metadata","aws/corehandlers","aws/credentials","aws/credentials/ec2rolecreds","aws/credentials/endpointcreds","aws/credentials/stscreds","aws/defaults","aws/ec2metadata","aws/endpoints","aws/request","aws/session","aws/signer/v4","internal/shareddefaults","private/protocol","private/protocol/json/jsonutil","private/protocol/jsonrpc","private/protocol/query","private/protocol/query/queryutil","private/protocol/rest","private/protocol/restxml","private/protocol/xml/xmlutil","service/dynamodb","service/dynamodb/dynamodbattribute","service/dynamodb/dynamodbiface","service/kinesis","service/kinesis/kinesisiface","service/s3","service/s3/s3iface","service/s3/s3manager","service/sts"]
   revision = "1850f427c33c2558a2118dc55c1cf95a633d7432"
   version = "v1.10.27"
 
@@ -62,24 +27,14 @@
 
 [[projects]]
   name = "github.com/gogo/protobuf"
-  packages = [
-    "gogoproto",
-    "jsonpb",
-    "proto",
-    "protoc-gen-gogo/descriptor",
-    "sortkeys",
-    "types"
-  ]
+  packages = ["gogoproto","jsonpb","proto","protoc-gen-gogo/descriptor","sortkeys","types"]
   revision = "100ba4e885062801d56799d78530b73b178a78f3"
   version = "v0.4"
 
 [[projects]]
   branch = "master"
   name = "github.com/golang/protobuf"
-  packages = [
-    "proto",
-    "ptypes/any"
-  ]
+  packages = ["proto","ptypes/any"]
   revision = "ab9f9a6dab164b7d1246e0e688b0ab7b94d8553e"
 
 [[projects]]
@@ -91,17 +46,7 @@
 [[projects]]
   branch = "master"
   name = "github.com/hashicorp/hcl"
-  packages = [
-    ".",
-    "hcl/ast",
-    "hcl/parser",
-    "hcl/scanner",
-    "hcl/strconv",
-    "hcl/token",
-    "json/parser",
-    "json/scanner",
-    "json/token"
-  ]
+  packages = [".","hcl/ast","hcl/parser","hcl/scanner","hcl/strconv","hcl/token","json/parser","json/scanner","json/token"]
   revision = "392dba7d905ed5d04a5794ba89f558b27e2ba1ca"
 
 [[projects]]
@@ -148,20 +93,14 @@
 
 [[projects]]
   name = "github.com/sirupsen/logrus"
-  packages = [
-    ".",
-    "hooks/test"
-  ]
+  packages = [".","hooks/test"]
   revision = "f006c2ac4710855cf0f916dd6b77acf6b048dc6e"
   version = "v1.0.3"
 
 [[projects]]
   branch = "master"
   name = "github.com/spf13/afero"
-  packages = [
-    ".",
-    "mem"
-  ]
+  packages = [".","mem"]
   revision = "9be650865eab0c12963d8753212f4f9c66cdcf12"
 
 [[projects]]
@@ -203,10 +142,7 @@
 [[projects]]
   branch = "master"
   name = "github.com/twitchscience/kinsumer"
-  packages = [
-    ".",
-    "mocks"
-  ]
+  packages = [".","mocks"]
   revision = "f26b4530a818a64678ddf55602912d1556f19a67"
 
 [[projects]]
@@ -236,40 +172,19 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
-  packages = [
-    "context",
-    "http2",
-    "http2/hpack",
-    "idna",
-    "internal/timeseries",
-    "lex/httplex",
-    "trace"
-  ]
+  packages = ["context","http2","http2/hpack","idna","internal/timeseries","lex/httplex","trace"]
   revision = "1c05540f6879653db88113bc4a2b70aec4bd491f"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
-  packages = [
-    "unix",
-    "windows"
-  ]
+  packages = ["unix","windows"]
   revision = "9f7170bcd8e9f4d3691c06401119c46a769a1e03"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/text"
-  packages = [
-    "internal/gen",
-    "internal/triegen",
-    "internal/ucd",
-    "secure/bidirule",
-    "transform",
-    "unicode/bidi",
-    "unicode/cldr",
-    "unicode/norm",
-    "unicode/rangetable"
-  ]
+  packages = ["internal/gen","internal/triegen","internal/ucd","secure/bidirule","transform","unicode/bidi","unicode/cldr","unicode/norm","unicode/rangetable"]
   revision = "e56139fd9c5bc7244c76116c68e500765bb6db6b"
 
 [[projects]]
@@ -280,23 +195,7 @@
 
 [[projects]]
   name = "google.golang.org/grpc"
-  packages = [
-    ".",
-    "codes",
-    "connectivity",
-    "credentials",
-    "grpclb/grpc_lb_v1",
-    "grpclog",
-    "internal",
-    "keepalive",
-    "metadata",
-    "naming",
-    "peer",
-    "stats",
-    "status",
-    "tap",
-    "transport"
-  ]
+  packages = [".","codes","connectivity","credentials","grpclb/grpc_lb_v1","grpclog","internal","keepalive","metadata","naming","peer","stats","status","tap","transport"]
   revision = "b3ddf786825de56a4178401b7e174ee332173b66"
   version = "v1.5.2"
 
@@ -309,6 +208,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "4bc16827c7111f7327a8397383c40d569125a15c1d9ff52d84763ed7a40ac502"
+  inputs-digest = "e2705d18c490916055d516bddbabd5fecd7c1188e0dde69aafe07f380a13ca32"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -31,10 +31,6 @@
 
 [[constraint]]
   branch = "master"
-  name = "github.com/golang/protobuf"
-
-[[constraint]]
-  branch = "master"
   name = "github.com/gorilla/schema"
 
 [[constraint]]

--- a/README.md
+++ b/README.md
@@ -145,7 +145,11 @@ The name of the backend used as the RDSS broker. `"kinesis"` is the backend curr
 
 > Default: `true`
 
-When set to `true`, the adapter will validate incoming messages against the canonical schema documents. It is discouraged to disable it.
+The adapter implements a message validator that uses the canonical RDSS JSON Schema documents. The validator can be configured in the following ways:
+
+- When set to `true`, the adapter will reject invalid messages and the validation issues will be logged with `DEBUG` level.
+- When set to `warnings`, the adapter will not reject invalid messages but the validation issues will be logged with `DEBUG` level.
+- When set to `false`, message validation will not be performed.
 
 :heavy_minus_sign: `BROKER.QUEUES.MAIN`
 

--- a/broker/config.go
+++ b/broker/config.go
@@ -1,13 +1,17 @@
 package broker
 
-import "errors"
+import (
+	"errors"
+
+	"github.com/spf13/cast"
+)
 
 type Config struct {
 	QueueMain        string
 	QueueInvalid     string
 	QueueError       string
 	RepositoryConfig *RepositoryConfig
-	Validation       bool
+	Validation       ValidationMode
 }
 
 type RepositoryConfig struct {
@@ -30,10 +34,37 @@ func (c *Config) Validate() error {
 	}
 	if c.RepositoryConfig == nil || c.RepositoryConfig.Backend == "" {
 		return errors.New("repository config is undefined")
-	} else {
-		if c.RepositoryConfig.Backend == "dynamodb" && c.RepositoryConfig.DynamoDBTable == "" {
-			return errors.New("repository config is missing details")
-		}
+	}
+	if c.RepositoryConfig.Backend == "dynamodb" && c.RepositoryConfig.DynamoDBTable == "" {
+		return errors.New("repository config is missing details")
 	}
 	return nil
+}
+
+// ValidationMode determines the type of message validation that the client
+// is going to perform when new messages are received.
+type ValidationMode int
+
+const (
+	// Messages are rejected if invalid, validation issues will be logged.
+	ValidationModeStrict ValidationMode = iota
+
+	// Messages will not be rejected but the validation issues will be logged.
+	ValidationModeWarnings
+
+	// Message validator is disabled.
+	ValidationModeDisabled
+)
+
+func (c *Config) SetValidationMode(mode string) {
+	if enabled, err := cast.ToBoolE(mode); err == nil && !enabled {
+		c.Validation = ValidationModeDisabled
+		return
+	}
+	if mode == "warnings" {
+		c.Validation = ValidationModeWarnings
+		return
+	}
+	// Our default is the strict mode.
+	c.Validation = ValidationModeStrict
 }

--- a/broker/config_test.go
+++ b/broker/config_test.go
@@ -1,6 +1,8 @@
 package broker
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestConfig_Validate(t *testing.T) {
 	tests := []struct {
@@ -58,5 +60,24 @@ func TestConfig_Validate(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestConfig_SetValidationMode(t *testing.T) {
+	testCases := []struct {
+		input string
+		want  ValidationMode
+	}{
+		{"false", ValidationModeDisabled},
+		{"warnings", ValidationModeWarnings},
+		{"true", ValidationModeStrict},
+		{"", ValidationModeStrict},
+	}
+	config := &Config{}
+	for _, tc := range testCases {
+		config.SetValidationMode(tc.input)
+		if have := config.Validation; have != tc.want {
+			t.Errorf("SetValidationMode(); given %s, have %v, want %v", tc.input, have, tc.want)
+		}
 	}
 }

--- a/broker/message/message.go
+++ b/broker/message/message.go
@@ -45,6 +45,9 @@ type messageAlias struct {
 }
 
 func (m *Message) ID() string {
+	if m.MessageHeader.ID == nil {
+		return ""
+	}
 	return m.MessageHeader.ID.String()
 }
 

--- a/broker/message/validation.go
+++ b/broker/message/validation.go
@@ -173,6 +173,8 @@ func decodeJson(r io.Reader) (interface{}, error) {
 // NoOpValidator is a validator that recognizes all messages as valid.
 type NoOpValidator struct{}
 
+var _ Validator = NoOpValidator{}
+
 // Validate implementes Validator.
 func (v NoOpValidator) Validate(msg *Message) (*gojsonschema.Result, error) {
 	return &gojsonschema.Result{}, nil

--- a/cmd/consumer/consumer.go
+++ b/cmd/consumer/consumer.go
@@ -109,7 +109,6 @@ func createBrokerClient() (*broker.Broker, error) {
 		QueueInvalid:     viper.GetString("broker.queues.invalid"),
 		QueueError:       viper.GetString("broker.queues.error"),
 		RepositoryConfig: repoConfig,
-		Validation:       viper.GetBool("broker.validation"),
 	}
 	if repoConfig.Backend == "dynamodb" {
 		repoConfig.DynamoDBEndpoint = viper.GetString("broker.repository.dynamodb_endpoint")
@@ -117,6 +116,7 @@ func createBrokerClient() (*broker.Broker, error) {
 		repoConfig.DynamoDBTable = viper.GetString("broker.repository.dynamodb_table")
 		repoConfig.DynamoDBTLS = viper.GetBool("broker.repository.dynamodb_tls")
 	}
+	brokerConfig.SetValidationMode(viper.GetString("broker.validation"))
 
 	return broker.New(ba, logger, brokerConfig)
 }


### PR DESCRIPTION
This is in addition to #80 (see also #77). It extends the possible uses of the environment string `RDSS_ARCHIVEMATICA_ADAPTER_BROKER.VALIDATION`. These are the options:

- When set to `true`, the adapter will reject invalid messages and the validation issues will be logged with `DEBUG` level.
- When set to warnings, the adapter will not reject invalid messages but the validation issues will be logged with `DEBUG` level.
- When set to `false`, message validation will not be performed.

`true` remains as the default value.