### PR TITLE
Travis: use Go 1.x and tip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,12 @@
 ---
 language: go
 go:
-  - 1.9.1
+  - 1.x
+  - tip
+matrix:
+  allow_failures:
+    - go: tip
+  fast_finish: true
 install:
   - make tools
   - go get github.com/mattn/goveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,9 @@ install:
   - make tools
   - go get github.com/mattn/goveralls
 script:
-  - $HOME/gopath/bin/goveralls -service=travis-ci
+  - $HOME/gopath/bin/goveralls
+      -ignore=publisher/pb/rpc.pb.go,broker/message/specdata/specdata.go
+      -service=travis-ci
   - make
   - make vendor-status
 notifications:


### PR DESCRIPTION
Travis translates `1.x` into the latest minor version available.

Effectively this means that we would be using Go 1.10 (released four days ago), but it also means that we don't have to keep updating `.travis.yml` when new versions of Go are released.

Also, added `tip` to test against new versions in development.
Allow it to fail.