### PR TITLE
minikine: use kinesalite v1.11.7

### DIFF
--- a/hack/minikine/package.json
+++ b/hack/minikine/package.json
@@ -9,6 +9,6 @@
   "dependencies": {
     "aws-sdk": "^2.39.0",
     "dynalite": "^1.2.0",
-    "kinesalite": "git://github.com/teamdoug/kinesalite.git#dwe-default-time"
+    "kinesalite": "^1.11.7"
   }
 }


### PR DESCRIPTION
[kinesalite v1.11.7](https://github.com/mhart/kinesalite/releases/tag/v1.11.7) has been released today and it includes a fix for a problem we experienced with messages being delivered more than once. We had to use a fork but that's not necessary anymore once we install the update.