### PR TITLE
Support async start transfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ Archivematica API - Username, e.g.:  `"demo"`.
 
 Archivematica API - Key, e.g.: `"eid3Aitheijoo1ohce2pho4eiDei0lah"`.
 
+:heavy_minus_sign: `AMCLIENT.TRANSFER_DIR`
+
+> Default: `""`
+
+The base directory where transfers will be downloaded. It must match the path of the default transfer source location as defined in Archivematica Storage Service. For a development environment, the default is `/home`. Transfers will be downloaded into temporary directories created inside the `TRANSFER_DIR`.
+
 :heavy_minus_sign: `S3.FORCE_PATH_STYLE`
 
 > Default: `false`
@@ -104,12 +110,6 @@ When set to a non-empty string, it's combined with `S3.ACCESS_KEY` to set up the
 > Default: `""`
 
 AWS Region. If empty, the AWS SDK will throw an error. E.g.: `eu-west-2`.
-
-:heavy_minus_sign: `CONSUMER.ARCHIVEMATICA_SHARED_DIR`
-
-> Default: `"/var/archivematica/sharedDirectory"`
-
-Location of the Archivematica Shared Directory.
 
 :heavy_minus_sign: `CONSUMER.BACKEND`
 

--- a/amclient/amclient.go
+++ b/amclient/amclient.go
@@ -39,6 +39,7 @@ type Client struct {
 	// Services used for communicating with the API
 	Transfer         TransferService
 	ProcessingConfig ProcessingConfigService
+	Package          PackageService
 
 	// Local temporary filesystem. See transfer_session.go for more details.
 	Fs afero.Fs
@@ -79,6 +80,7 @@ func NewClient(httpClient *http.Client, bu, u, k string) *Client {
 	}
 	c.Transfer = &TransferServiceOp{client: c}
 	c.ProcessingConfig = &ProcessingConfigOp{client: c}
+	c.Package = &PackageServiceOp{client: c}
 	return c
 }
 

--- a/amclient/v2_package.go
+++ b/amclient/v2_package.go
@@ -1,0 +1,51 @@
+package amclient
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+)
+
+const packageBasePath = "api/v2beta/package"
+
+type PackageService interface {
+	Create(context.Context, *PackageCreateRequest) (*PackageCreateResponse, *Response, error)
+}
+
+type PackageServiceOp struct {
+	client *Client
+}
+
+var _ PackageService = &PackageServiceOp{}
+
+type PackageCreateRequest struct {
+	Name          string `json:"name"`
+	Type          string `json:"type"`
+	Accession     string `json:"accession"`
+	Path          string `json:"path"`
+	MetadataSetID string `json:"metadata_set_id"`
+}
+
+type PackageCreateResponse struct {
+	ID string `json:"id,omitempty"`
+}
+
+func (s *PackageServiceOp) Create(ctx context.Context, r *PackageCreateRequest) (*PackageCreateResponse, *Response, error) {
+	path := fmt.Sprintf("%s/", packageBasePath)
+
+	if r.Type == "" {
+		r.Type = standardTransferType
+	}
+
+	r.Path = base64.StdEncoding.EncodeToString([]byte(r.Path))
+
+	req, err := s.client.NewRequestJSON(ctx, "POST", path, r)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	payload := &PackageCreateResponse{}
+	resp, err := s.client.Do(ctx, req, payload)
+
+	return payload, resp, err
+}

--- a/amclient/v2_package.go
+++ b/amclient/v2_package.go
@@ -30,6 +30,8 @@ type PackageCreateResponse struct {
 	ID string `json:"id,omitempty"`
 }
 
+const standardTransferType = "standard"
+
 func (s *PackageServiceOp) Create(ctx context.Context, r *PackageCreateRequest) (*PackageCreateResponse, *Response, error) {
 	path := fmt.Sprintf("%s/", packageBasePath)
 

--- a/amclient/v2_package_test.go
+++ b/amclient/v2_package_test.go
@@ -1,0 +1,41 @@
+package amclient
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"testing"
+)
+
+func TestPackage_Create(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/api/v2beta/package/", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+
+		blob, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer r.Body.Close()
+		var expected = []byte(`{"name":"Foobar","type":"standard","accession":"","path":"PHV1aWQ+OjxwYXRoPg==","metadata_set_id":""}`)
+		if !bytes.Equal(bytes.TrimSpace(blob), expected) {
+			t.Fatal("path attribute does not have the expected value")
+		}
+
+		fmt.Fprint(w, `{"id": "096a284d-5067-4de0-a0a4-a684018cd6df"}`)
+	})
+
+	req := &PackageCreateRequest{
+		Name: "Foobar",
+		Type: "standard",
+		Path: "<uuid>:<path>",
+	}
+	payload, _, _ := client.Package.Create(ctx, req)
+
+	if want, got := "096a284d-5067-4de0-a0a4-a684018cd6df", payload.ID; want != got {
+		t.Errorf("Package.Create() id: got %v, want %v", got, want)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,10 +20,10 @@ const defaultConfig = `# RDSS Archivematica Channel Adapter
 level = "INFO"
 
 [amclient]
-# URL of the Archivematica Dashboard
 url = ""
 user = ""
 key = ""
+transfer_dir = ""
 
 [s3]
 force_path_style = false
@@ -34,7 +34,6 @@ secret_key = ""
 region = ""
 
 [consumer]
-archivematica_shared_dir = "/var/archivematica/sharedDirectory"
 backend = "builtin"
 dynamodb_tls = true
 dynamodb_table = "consumer_storage"

--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -29,12 +29,11 @@ type Consumer interface {
 
 // ConsumerImpl is an implementation of Consumer.
 type ConsumerImpl struct {
-	broker     *broker.Broker
-	ctx        context.Context
-	logger     log.FieldLogger
-	amc        *amclient.Client
-	s3         s3.ObjectStorage
-	amSharedFs afero.Fs
+	broker *broker.Broker
+	ctx    context.Context
+	logger log.FieldLogger
+	amc    *amclient.Client
+	s3     s3.ObjectStorage
 
 	// storage supports the persistency of certain data attributes that we
 	// need to access to implement a RDSS preservation system.
@@ -48,16 +47,14 @@ func MakeConsumer(
 	broker *broker.Broker,
 	amc *amclient.Client,
 	s3 s3.ObjectStorage,
-	amSharedFs afero.Fs,
 	storage Storage) *ConsumerImpl {
 	return &ConsumerImpl{
-		ctx:        ctx,
-		logger:     logger,
-		broker:     broker,
-		amc:        amc,
-		s3:         s3,
-		amSharedFs: amSharedFs,
-		storage:    storage,
+		ctx:     ctx,
+		logger:  logger,
+		broker:  broker,
+		amc:     amc,
+		s3:      s3,
+		storage: storage,
 	}
 }
 
@@ -133,7 +130,7 @@ func (c *ConsumerImpl) startTransfer(body *message.ResearchObject) (string, erro
 	if len(body.ObjectFile) == 0 {
 		return "", nil
 	}
-	t, err := c.amc.TransferSession(body.ObjectTitle, c.amSharedFs)
+	t, err := c.amc.TransferSession(body.ObjectTitle)
 	if err != nil {
 		return "", err
 	}

--- a/consumer/consumer_test.go
+++ b/consumer/consumer_test.go
@@ -72,15 +72,11 @@ func tearUp() {
 	server = httptest.NewServer(mux)
 	url, _ := url.Parse(server.URL)
 	amc, _ := amclient.New(nil, url.String(), "", "", amclient.SetFs(fs))
-	fs := afero.NewBasePathFs(afero.NewMemMapFs(), "/")
 
 	ctx, cancel = context.WithCancel(context.Background())
 
 	// Consumer with mocks
-	c = consumer.MakeConsumer(
-		ctx, logger,
-		br, amc, &RandomObjectStorage{}, fs,
-		consumer.NewStorageInMemory())
+	c = consumer.MakeConsumer(ctx, logger, br, amc, &RandomObjectStorage{}, consumer.NewStorageInMemory())
 
 	go func() {
 		c.Start()


### PR DESCRIPTION
- [x] amclient: allow JSON requests.
So far we only had implemented form-encoded requests (used in the v1 namespace of Dashboard API).
- [x] amclient: add `amclient.PackageService` to support new `/api/v2beta/package`
This is just the internal abstraction to interface with any endpoint made available under `/api/v2beta/package`.
- [x] amclient: update `amclient.TransferSession` so it uses `amclient.PackageService` and it stops using the Archivematica Shared Directory directly to start transfers - instead it stores the transfers in a new temporary directory created inside `AMCLIENT.TRANSFER_DIR` (configurable attribute) which should be a transfer source location. See more details below.
- [x] consumer: look up `AMCLIENT.TRANSFER_DIR` and pass to `amclient.TransferSession` (using afero filesystem abstraction).

---

`amclient.TransferSession` is an abstraction that simplifies the creation of a transfer. It's used by our `MetadataCreate` handler whenever we're ready to start a transfer. Roughly, it used to do the following:
1. Create a temporary directory in the Archivematica Shared Directory.
2. Download and include a processing configuration.
3. Incorporate files to the transfer (`objects/`).
4. Incorporate checksums and metadata in the transfer directory.
5. Move the transfer to the watched directory.
6. Approve the transfer (with retry/backoff).

The new process is:
1. Create a temporary directory in `AMCLIENT.TRANSFER_DIR`.
2. and 3. and 4. are the same.
5. Call create package API.

This depends on https://github.com/archivematica/Issues/issues/21.
This closes #104.