### PR TITLE
Add handler for MetadataUpdate message

### DIFF
--- a/amclient/transfer_session_test.go
+++ b/amclient/transfer_session_test.go
@@ -69,7 +69,9 @@ func (tsm *transferServiceMock) Start(ctx context.Context, req *TransferStartReq
 
 func (tsm *transferServiceMock) Approve(ctx context.Context, req *TransferApproveRequest) (*TransferApproveResponse, *Response, error) {
 	tsm.approveReq = req
-	return &TransferApproveResponse{}, &Response{}, nil
+	return &TransferApproveResponse{
+		UUID: "13d9e74c-f88a-44c3-9657-c756eb3fa1c8",
+	}, &Response{}, nil
 }
 
 func (tsm *transferServiceMock) Unapproved(ctx context.Context, req *TransferUnapprovedRequest) (*TransferUnapprovedResponse, *Response, error) {
@@ -275,8 +277,12 @@ func TestTransferSession_createMetadataDir(t *testing.T) {
 func TestTransferSession_Start(t *testing.T) {
 	ts := newTransferSession(t, "Test")
 
-	if err := ts.Start(); err != nil {
+	id, err := ts.Start()
+	if err != nil {
 		t.Fatalf("TransferSession.Start() failed: %v", err)
+	}
+	if have, want := id, ts.id; have != want {
+		t.Errorf("Have %s, want %s", have, want)
 	}
 
 	transferService := ts.c.Transfer.(*transferServiceMock)

--- a/broker/message/message_metadata.go
+++ b/broker/message/message_metadata.go
@@ -15,7 +15,7 @@ type MetadataCreateRequest struct {
 func (m Message) MetadataCreateRequest() (*MetadataCreateRequest, error) {
 	body, ok := m.MessageBody.(*MetadataCreateRequest)
 	if !ok {
-		return nil, fmt.Errorf("interface conversion error")
+		return nil, fmt.Errorf("MetadataCreateRequest(): interface conversion error")
 	}
 	return body, nil
 }
@@ -31,7 +31,7 @@ type MetadataReadRequest struct {
 func (m Message) MetadataReadRequest() (*MetadataReadRequest, error) {
 	b, ok := m.MessageBody.(*MetadataReadRequest)
 	if !ok {
-		return nil, fmt.Errorf("interface conversion error")
+		return nil, fmt.Errorf("MetadataReadRequest(): interface conversion error")
 	}
 	return b, nil
 }
@@ -45,7 +45,7 @@ type MetadataReadResponse struct {
 func (m Message) MetadataReadResponse() (*MetadataReadResponse, error) {
 	b, ok := m.MessageBody.(*MetadataReadResponse)
 	if !ok {
-		return nil, fmt.Errorf("interface conversion error")
+		return nil, fmt.Errorf("MetadataReadResponse(): interface conversion error")
 	}
 	return b, nil
 }
@@ -61,7 +61,7 @@ type MetadataUpdateRequest struct {
 func (m Message) MetadataUpdateRequest() (*MetadataUpdateRequest, error) {
 	b, ok := m.MessageBody.(*MetadataUpdateRequest)
 	if !ok {
-		return nil, fmt.Errorf("interface conversion error")
+		return nil, fmt.Errorf("MetadataUpdateRequest(): interface conversion error")
 	}
 	return b, nil
 }
@@ -77,7 +77,7 @@ type MetadataDeleteRequest struct {
 func (m Message) MetadataDeleteRequest() (*MetadataDeleteRequest, error) {
 	b, ok := m.MessageBody.(*MetadataDeleteRequest)
 	if !ok {
-		return nil, fmt.Errorf("interface conversion error")
+		return nil, fmt.Errorf("MetadataDeleteRequest(): interface conversion error")
 	}
 	return b, nil
 }

--- a/broker/message/message_vocabulary.go
+++ b/broker/message/message_vocabulary.go
@@ -9,7 +9,7 @@ type VocabularyReadRequest struct {
 func (m Message) VocabularyReadRequest() (*VocabularyReadRequest, error) {
 	b, ok := m.MessageBody.(*VocabularyReadRequest)
 	if !ok {
-		return nil, fmt.Errorf("interface conversion error")
+		return nil, fmt.Errorf("VocabularyReadRequest(): interface conversion error")
 	}
 	return b, nil
 }
@@ -22,7 +22,7 @@ type VocabularyReadResponse struct {
 func (m Message) VocabularyReadResponse() (*VocabularyReadResponse, error) {
 	b, ok := m.MessageBody.(*VocabularyReadResponse)
 	if !ok {
-		return nil, fmt.Errorf("interface conversion error")
+		return nil, fmt.Errorf("VocabularyReadResponse(): interface conversion error")
 	}
 	return b, nil
 }
@@ -36,7 +36,7 @@ type VocabularyPatchRequest struct {
 func (m Message) VocabularyPatchRequest() (*VocabularyPatchRequest, error) {
 	b, ok := m.MessageBody.(*VocabularyPatchRequest)
 	if !ok {
-		return nil, fmt.Errorf("interface conversion error")
+		return nil, fmt.Errorf("VocabularyPatchRequest(): interface conversion error")
 	}
 	return b, nil
 }

--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -17,6 +17,11 @@ import (
 	"github.com/JiscRDSS/rdss-archivematica-channel-adapter/s3"
 )
 
+// The name of the processing configuration that we're going to include in the
+// transfers. The name is convened and the server ensures that it's going to be
+// available at all times.
+const automatedProcessingConfiguration = "automated"
+
 // Consumer is the component that subscribes to the broker and interacts with
 // Archivematica.
 type Consumer interface {
@@ -79,9 +84,9 @@ func (c *ConsumerImpl) handleMetadataCreateRequest(msg *message.Message) error {
 	}
 
 	// Download automated workflow.
-	err = t.ProcessingConfig("automated")
+	err = t.ProcessingConfig(automatedProcessingConfiguration)
 	if err != nil {
-		c.logger.Warningf("Failed to download `automated` processing configuration: %s", err)
+		c.logger.Warningf("Failed to download `%s` processing configuration: %s", automatedProcessingConfiguration, err)
 	}
 
 	// Process dataset metadata.

--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -127,7 +127,13 @@ func (c *ConsumerImpl) handleMetadataCreateRequest(msg *message.Message) error {
 		return err
 	}
 
-	return t.Start()
+	id, err := t.Start()
+	if err != nil {
+		return err
+	}
+	c.logger.Debugf("The transfer has started successfully, id: %s", id)
+
+	return nil
 }
 
 // retry is a retry-backoff time provider that manages times between retries for the http storage type.

--- a/consumer/storage.go
+++ b/consumer/storage.go
@@ -1,0 +1,41 @@
+package consumer
+
+import (
+	"context"
+	"sync"
+)
+
+type storage interface {
+	AssociateResearchObject(ctx context.Context, objectUUID string, transferID string) error
+	GetResearchObject(ctx context.Context, objectUUID string) (string, error)
+}
+
+var _ storage = &storageInMemoryImpl{}
+
+func newStorageInMemory() *storageInMemoryImpl {
+	return &storageInMemoryImpl{
+		h: make(map[string]string),
+	}
+}
+
+type storageInMemoryImpl struct {
+	h map[string]string
+	sync.RWMutex
+}
+
+func (s *storageInMemoryImpl) AssociateResearchObject(ctx context.Context, objectUUID string, transferID string) error {
+	s.Lock()
+	defer s.Unlock()
+	s.h[objectUUID] = transferID
+	return nil
+}
+
+func (s *storageInMemoryImpl) GetResearchObject(ctx context.Context, objectUUID string) (string, error) {
+	s.RLock()
+	defer s.RUnlock()
+	ret, ok := s.h[objectUUID]
+	if !ok {
+		return "", nil
+	}
+	return ret, nil
+}

--- a/consumer/storage_test.go
+++ b/consumer/storage_test.go
@@ -1,0 +1,23 @@
+package consumer
+
+import (
+	"context"
+	"testing"
+)
+
+func TestStorageInMemoryImpl(t *testing.T) {
+	ctx := context.Background()
+	s := newStorageInMemory()
+
+	id, _ := s.GetResearchObject(ctx, "foo")
+	if have, want := id, ""; have != want {
+		t.Fatalf("GetResearchObject(); have `%s` want `%s`", have, want)
+	}
+
+	_ = s.AssociateResearchObject(ctx, "foo", "bar")
+
+	id, _ = s.GetResearchObject(ctx, "foo")
+	if have, want := id, "bar"; have != want {
+		t.Fatalf("GetResearchObject(); have `%s` want `%s`", have, want)
+	}
+}


### PR DESCRIPTION
Related links:
- https://jiscdev.atlassian.net/browse/RDSSARK-491
- https://jiscdev.atlassian.net/wiki/spaces/RDSSAR/pages/429064213/Metadata+Update+Messages

Limitations:
- Re-ingest doesn't happen yet, we're just starting a new transfer.
- The only implementation at the moment of the `Storage` interface puts the data in memory (basically a hash of ObjectUUID » TransferUUID). I will ~update the PR soon~ **submit a new PR** with an implementation for DynamoDB.

```
time="2018-03-26T02:06:06Z" level=info msg="Message received" cmd=consumer count=3 type=MetadataUpdate version=UNKNOWN
time="2018-03-26T02:06:06Z" level=debug msg="Reingesting transfer." TODO="Implement real reingest." cmd=consumer handler=MetadataUpdate message=efac164a-c9bd-45e0-8991-2c505e400300 transferID=869ceae0-f5ef-434e-a460-38be4e6e4902 version=UNKNOWN
```