### PR TITLE
consumer: add DynamoDB storage backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,36 @@ AWS Region. If empty, the AWS SDK will throw an error. E.g.: `eu-west-2`.
 
 Location of the Archivematica Shared Directory.
 
+:heavy_minus_sign: `CONSUMER.BACKEND`
+
+> Default: `"builtin"`
+
+The default (`"builtin"`) is a simple non-persisted hash in memory. A better alternative that can be shared by multiple consumers is the `dynamodb` backend which uses a single DynamoDB table.
+
+:heavy_minus_sign: `CONSUMER.DYNAMODB_TLS`
+
+> Default: `true`
+
+When set to `true`, the client uses the TLS protocol to communicate securely with the server. If you are using a clone of DynamoDB like dynalite you may prefer to have it disabled.
+
+:heavy_minus_sign: `CONSUMER.DYNAMODB_TABLE`
+
+> Default: `""`
+
+The DynamoDB table name which must conform the [naming rules](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.NamingRules).
+
+:heavy_minus_sign: `CONSUMER.DYNAMODB_ENDPOINT`
+
+> Default: `""`
+
+When set to a non-empty string, it's used as the AWS service endpoint, e.g.: `"http://127.0.0.1:9999"`.
+
+:heavy_minus_sign: `CONSUMER.DYNAMODB_REGION`
+
+> Default: `""`
+
+AWS Region. If empty, the AWS SDK will throw an error. E.g.: `eu-west-2`.
+
 :heavy_minus_sign: `PUBLISHER.LISTEN`
 
 > Default: `"0.0.0.0:8000"`

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,6 +35,11 @@ region = ""
 
 [consumer]
 archivematica_shared_dir = "/var/archivematica/sharedDirectory"
+backend = "builtin"
+dynamodb_tls = true
+dynamodb_table = "consumer_storage"
+dynamodb_endpoint = ""
+dynamodb_region = ""
 
 [publisher]
 listen = "0.0.0.0:8000"

--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -38,7 +38,7 @@ type ConsumerImpl struct {
 
 	// storage supports the persistency of certain data attributes that we
 	// need to access to implement a RDSS preservation system.
-	storage storage
+	storage Storage
 }
 
 // MakeConsumer returns a new ConsumerImpl which implements Consumer
@@ -48,7 +48,8 @@ func MakeConsumer(
 	broker *broker.Broker,
 	amc *amclient.Client,
 	s3 s3.ObjectStorage,
-	amSharedFs afero.Fs) *ConsumerImpl {
+	amSharedFs afero.Fs,
+	storage Storage) *ConsumerImpl {
 	return &ConsumerImpl{
 		ctx:        ctx,
 		logger:     logger,
@@ -56,7 +57,7 @@ func MakeConsumer(
 		amc:        amc,
 		s3:         s3,
 		amSharedFs: amSharedFs,
-		storage:    newStorageInMemory(),
+		storage:    storage,
 	}
 }
 

--- a/consumer/consumer_test.go
+++ b/consumer/consumer_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"
 	logt "github.com/sirupsen/logrus/hooks/test"
 	"github.com/spf13/afero"
 
@@ -77,18 +78,19 @@ func tearUp() {
 
 	// Consumer with mocks
 	c = consumer.MakeConsumer(
-		ctx,
-		logger,
-		br,
-		amc,
-		&RandomObjectStorage{},
-		fs)
+		ctx, logger,
+		br, amc, &RandomObjectStorage{}, fs,
+		consumer.NewStorageInMemory())
 
 	go func() {
 		c.Start()
 		stop <- struct{}{}
 		cancel() // just to make vet happy
 	}()
+}
+
+type dynamodbmock struct {
+	dynamodbiface.DynamoDBAPI
 }
 
 func tearDown() {

--- a/consumer/consumer_unit_test.go
+++ b/consumer/consumer_unit_test.go
@@ -221,7 +221,7 @@ func getConsumer(t *testing.T) (*ConsumerImpl, *logt.Hook) {
 	c := &ConsumerImpl{
 		ctx:     context.Background(),
 		logger:  logger,
-		storage: newStorageInMemory(),
+		storage: NewStorageInMemory(),
 	}
 	return c, hook
 }

--- a/consumer/storage.go
+++ b/consumer/storage.go
@@ -2,17 +2,23 @@ package consumer
 
 import (
 	"context"
+	"fmt"
 	"sync"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
+	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"
 )
 
-type storage interface {
+type Storage interface {
 	AssociateResearchObject(ctx context.Context, objectUUID string, transferID string) error
 	GetResearchObject(ctx context.Context, objectUUID string) (string, error)
 }
 
-var _ storage = &storageInMemoryImpl{}
+var _ Storage = (*storageInMemoryImpl)(nil)
 
-func newStorageInMemory() *storageInMemoryImpl {
+func NewStorageInMemory() *storageInMemoryImpl {
 	return &storageInMemoryImpl{
 		h: make(map[string]string),
 	}
@@ -38,4 +44,58 @@ func (s *storageInMemoryImpl) GetResearchObject(ctx context.Context, objectUUID 
 		return "", nil
 	}
 	return ret, nil
+}
+
+type storageDynamoDBImpl struct {
+	DynamoDB dynamodbiface.DynamoDBAPI
+	Table    string
+}
+
+func NewStorageDynamoDB(client dynamodbiface.DynamoDBAPI, table string) *storageDynamoDBImpl {
+	return &storageDynamoDBImpl{
+		DynamoDB: client,
+		Table:    table,
+	}
+}
+
+type storageItem struct {
+	ObjectUUID string `dynamodbav:"objectUUID"`
+	TransferID string `dynamodbav:"transferID"`
+}
+
+var _ Storage = (*storageDynamoDBImpl)(nil)
+
+func (s *storageDynamoDBImpl) AssociateResearchObject(ctx context.Context, objectUUID string, transferID string) error {
+	si := &storageItem{
+		ObjectUUID: objectUUID,
+		TransferID: transferID,
+	}
+	item, err := dynamodbattribute.MarshalMap(si)
+	if err != nil {
+		return err
+	}
+	input := &dynamodb.PutItemInput{
+		TableName: aws.String(s.Table),
+		Item:      item,
+	}
+	_, err = s.DynamoDB.PutItemWithContext(ctx, input)
+	return err
+}
+
+func (s *storageDynamoDBImpl) GetResearchObject(ctx context.Context, objectUUID string) (string, error) {
+	var input = &dynamodb.GetItemInput{
+		TableName: aws.String(s.Table),
+		Key: map[string]*dynamodb.AttributeValue{
+			"objectUUID": {S: aws.String(objectUUID)},
+		},
+	}
+	output, err := s.DynamoDB.GetItemWithContext(ctx, input)
+	if err != nil || output.Item == nil {
+		return "", fmt.Errorf("not found")
+	}
+	si := &storageItem{}
+	if err := dynamodbattribute.UnmarshalMap(output.Item, si); err != nil {
+		return "", err
+	}
+	return si.TransferID, nil
 }

--- a/consumer/storage_test.go
+++ b/consumer/storage_test.go
@@ -3,11 +3,17 @@ package consumer
 import (
 	"context"
 	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
+	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"
 )
 
 func TestStorageInMemoryImpl(t *testing.T) {
 	ctx := context.Background()
-	s := newStorageInMemory()
+	s := NewStorageInMemory()
 
 	id, _ := s.GetResearchObject(ctx, "foo")
 	if have, want := id, ""; have != want {
@@ -20,4 +26,49 @@ func TestStorageInMemoryImpl(t *testing.T) {
 	if have, want := id, "bar"; have != want {
 		t.Fatalf("GetResearchObject(); have `%s` want `%s`", have, want)
 	}
+}
+
+func TestStorageDynamoDBImpl(t *testing.T) {
+	ctx := context.Background()
+	dynamock := &mockDynamoDBClient{
+		GetItemWantedItem: &storageItem{ObjectUUID: "1", TransferID: "2"},
+	}
+	s := NewStorageDynamoDB(dynamock, "table")
+
+	id, _ := s.GetResearchObject(ctx, "foo")
+	if have, want := *dynamock.GetItemInput.Key["objectUUID"].S, "foo"; have != want {
+		t.Fatalf("GetResearchObject(); want %v, have %v", want, have)
+	}
+	if want, have := dynamock.GetItemWantedItem.(*storageItem).TransferID, id; want != have {
+		t.Fatalf("GetResearchObject(); want %v, have %v", want, have)
+	}
+
+	_ = s.AssociateResearchObject(ctx, "foo", "bar")
+	if have, want := *dynamock.PutItemInput.Item["objectUUID"].S, "foo"; have != want {
+		t.Fatalf("GetResearchObject(); want %v, have %v", want, have)
+	}
+	if have, want := *dynamock.PutItemInput.Item["transferID"].S, "bar"; have != want {
+		t.Fatalf("GetResearchObject(); want %v, have %v", want, have)
+	}
+}
+
+type mockDynamoDBClient struct {
+	dynamodbiface.DynamoDBAPI
+	GetItemWantedItem interface{}
+	GetItemInput      *dynamodb.GetItemInput
+	PutItemInput      *dynamodb.PutItemInput
+}
+
+func (m *mockDynamoDBClient) GetItemWithContext(ctx aws.Context, input *dynamodb.GetItemInput, opts ...request.Option) (*dynamodb.GetItemOutput, error) {
+	m.GetItemInput = input
+	item, err := dynamodbattribute.MarshalMap(m.GetItemWantedItem)
+	if err != nil {
+		return nil, err
+	}
+	return &dynamodb.GetItemOutput{Item: item}, nil
+}
+
+func (m *mockDynamoDBClient) PutItemWithContext(ctx aws.Context, input *dynamodb.PutItemInput, opts ...request.Option) (*dynamodb.PutItemOutput, error) {
+	m.PutItemInput = input
+	return &dynamodb.PutItemOutput{}, nil
 }

--- a/hack/minikine/dynalite.js
+++ b/hack/minikine/dynalite.js
@@ -32,6 +32,7 @@ function bootstrap(dynamo) {
     'rdss_am_clients': { 'key': 'ID' },
     'rdss_am_metadata': { 'key': 'Key' },
     'rdss_am_messages': { 'key': 'ID' },
+    'consumer_storage': { 'key': 'objectUUID' }
   }
   for (var prop in tables) {
     key = tables[prop].key


### PR DESCRIPTION
#91 added the `consumer.Storage` interface with a simple builtin in-memory implementation. This PR completes that work by adding support for DynamoDB.

Related: https://jiscdev.atlassian.net/browse/RDSSARK-491.