### PR TITLE
Handle panic in email validation

### DIFF
--- a/broker/message/validation.go
+++ b/broker/message/validation.go
@@ -243,7 +243,8 @@ func (f EmailFormatChecker) IsFormat(input interface{}) bool {
 	if asString == addressUsedInSpecExamples {
 		return true
 	}
-	return gojsonschema.FormatCheckers.IsFormat("email", asString)
+	emailFC := &gojsonschema.EmailFormatChecker{}
+	return emailFC.IsFormat(asString)
 }
 
 // See https://github.com/JiscRDSS/rdss-message-api-specification/commit/81af7c27c4adb10bba05ced436347789e67d6a14.


### PR DESCRIPTION
Tentative fix, needs further investigation.

Also, added `validate` command - useful if you want to validate a message but you don't have the whole stack running:

    go run main.go validate -f /home/foobar/message.json