### PR TITLE
Fix coverage report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,8 @@ matrix:
   fast_finish: true
 install:
   - make tools
-  - go get github.com/mattn/goveralls
 script:
-  - $HOME/gopath/bin/goveralls
-      -ignore=publisher/pb/rpc.pb.go,broker/message/specdata/specdata.go
-      -service=travis-ci
+  - hack/coverage.sh --coveralls
   - make
   - make vendor-status
 notifications:

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ This repository holds the source code of the channel adapter that connects Archi
 
 The adapter is written in Go as a standalone application that runs next to Archivematica. Its main role is to abstract the complexities and specifics of the underlying queuing system from its users.
 
+If you want to build this application from the sources, use Go 1.9 or newer. Our `Dockerfile` uses Go 1.9. Our CI uses `1.x` (latest release available) and `tip` (development branch).
+
 ## Usage
 
 We're producing a single binary executable file: **rdss-archivematica-channel-adapter** with two subcommands: **consumer** and **publisher**. You can build the Docker image locally running the following command:


### PR DESCRIPTION
Replace `coverage.sh` with a simpler script that ignores pb files effectively
and takes advantage of Go's most recent ability to hide vendor directories.

This brings the coverage report up to ~80% again.

This closes #96.