### PR TITLE
[3/4] Publish PreservationEvent message

### DIFF
--- a/adapter/handlers.go
+++ b/adapter/handlers.go
@@ -84,11 +84,7 @@ func (c *Adapter) startTransfer(researchObject *message.ResearchObject) (string,
 	if err != nil {
 		return "", err
 	}
-	// Download automated workflow.
-	err = t.ProcessingConfig(archivematicaProcessingConfig)
-	if err != nil {
-		c.logger.Warningf("Failed to download `%s` processing configuration: %s", archivematicaProcessingConfig, err)
-	}
+	t.WithProcessingConfig(archivematicaProcessingConfig)
 	// Process dataset metadata.
 	describeDataset(t, researchObject)
 	for _, file := range researchObject.ObjectFile {

--- a/amclient/amclient.go
+++ b/amclient/amclient.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
@@ -40,6 +39,8 @@ type Client struct {
 	Transfer         TransferService
 	ProcessingConfig ProcessingConfigService
 	Package          PackageService
+	Jobs             JobsService
+	Task             TaskService
 
 	// Local temporary filesystem. See transfer_session.go for more details.
 	Fs afero.Fs
@@ -81,6 +82,8 @@ func NewClient(httpClient *http.Client, bu, u, k string) *Client {
 	c.Transfer = &TransferServiceOp{client: c}
 	c.ProcessingConfig = &ProcessingConfigOp{client: c}
 	c.Package = &PackageServiceOp{client: c}
+	c.Jobs = &JobsServiceOp{client: c}
+	c.Task = &TaskServiceOp{client: c}
 	return c
 }
 
@@ -229,15 +232,5 @@ func CheckResponse(r *http.Response) error {
 	if c := r.StatusCode; c >= 200 && c <= 299 {
 		return nil
 	}
-
-	errorResponse := &ErrorResponse{Response: r}
-	data, err := ioutil.ReadAll(r.Body)
-	if err == nil && len(data) > 0 {
-		err := json.Unmarshal(data, errorResponse)
-		if err != nil {
-			return err
-		}
-	}
-
-	return errorResponse
+	return &ErrorResponse{Response: r}
 }

--- a/amclient/transfer.go
+++ b/amclient/transfer.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+
+	"github.com/twinj/uuid"
 )
 
 const transferBasePath = "api/transfer"
@@ -14,6 +16,7 @@ type TransferService interface {
 	Start(context.Context, *TransferStartRequest) (*TransferStartResponse, *Response, error)
 	Approve(context.Context, *TransferApproveRequest) (*TransferApproveResponse, *Response, error)
 	Unapproved(context.Context, *TransferUnapprovedRequest) (*TransferUnapprovedResponse, *Response, error)
+	Status(context.Context, string) (*TransferStatusResponse, *Response, error)
 }
 
 // TransferServiceOp handles communication with the Tranfer related methods of
@@ -107,6 +110,55 @@ func (s *TransferServiceOp) Unapproved(ctx context.Context, r *TransferUnapprove
 	}
 
 	payload := &TransferUnapprovedResponse{}
+	resp, err := s.client.Do(ctx, req, payload)
+
+	return payload, resp, err
+}
+
+type TransferStatusResponse struct {
+	ID           string `json:"uuid"`
+	Status       string `json:"status"`
+	Name         string `json:"name"`
+	SIPID        string `json:"sip_uuid"`
+	Microservice string `json:"microservice"`
+	Directory    string `json:"directory"`
+	Path         string `json:"path"`
+	Message      string `json:"message"`
+	Type         string `json:"type"`
+}
+
+func (t TransferStatusResponse) SIP() (string, bool) {
+	// From the API Docs:
+	//
+	// > Note: for consumers of this endpoint, it is possible for Archivematica
+	// > to return a status of COMPLETE without a sip_uuid. Consumers looking to
+	// > use the UUID of the AIP that will be created following Ingest should
+	// > therefore test for both a status of COMPLETE and the existence of
+	// > sip_uuid that does not also equal BACKLOG to ensure that they retrieve
+	// > it. This might mean an additional call to the status endpoint while this
+	// > data becomes available.
+	//
+	if t.Status != "COMPLETE" {
+		return "", false
+	}
+	if t.SIPID == "" || t.SIPID == "BACKLOG" {
+		return "", false
+	}
+	if _, err := uuid.Parse(t.SIPID); err != nil {
+		return "", false
+	}
+	return t.SIPID, true
+}
+
+func (s *TransferServiceOp) Status(ctx context.Context, ID string) (*TransferStatusResponse, *Response, error) {
+	path := fmt.Sprintf("%s/status/%s", transferBasePath, ID)
+
+	req, err := s.client.NewRequest(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	payload := &TransferStatusResponse{}
 	resp, err := s.client.Do(ctx, req, payload)
 
 	return payload, resp, err

--- a/amclient/transfer_session_test.go
+++ b/amclient/transfer_session_test.go
@@ -82,6 +82,9 @@ func TestNewTransferSession(t *testing.T) {
 	if have, want := ts.name, name; have != want {
 		t.Fatalf("NewTransferSession() unexpected name; have %s, want %s", have, want)
 	}
+	if have, want := ts.processingConfig, defaultProcessingConfig; have != want {
+		t.Fatalf("NewTransferSession() unexpected processingConfig; have %s, want %s", have, want)
+	}
 	if ts.Metadata == nil || ts.ChecksumsMD5 == nil || ts.ChecksumsSHA1 == nil || ts.ChecksumsSHA256 == nil {
 		t.Fatal("NewTransferSession() returned a TransferSession not initialized propery")
 	}
@@ -90,6 +93,14 @@ func TestNewTransferSession(t *testing.T) {
 	}
 	if contents, err := afero.ReadDir(ts.fs, "/"); err != nil || len(contents) > 0 {
 		t.Fatal("NewTransferSession() has an unexpected filesystem")
+	}
+}
+
+func TestTransferSession_WithProcessingConfig(t *testing.T) {
+	ts := newTransferSession(t, "Test").WithProcessingConfig("foobar")
+
+	if have, want := ts.processingConfig, "foobar"; have != want {
+		t.Fatalf("WithProcessingConfig() unexpected config; have %s, want %s", have, want)
 	}
 }
 

--- a/amclient/v2_jobs.go
+++ b/amclient/v2_jobs.go
@@ -1,0 +1,99 @@
+package amclient
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+const jobsBasePath = "api/v2beta/jobs"
+
+type JobsService interface {
+	List(context.Context, string, *JobsListRequest) ([]Job, *Response, error)
+}
+
+type JobsServiceOp struct {
+	client *Client
+}
+
+var _ JobsService = &JobsServiceOp{}
+
+type JobsListRequest struct {
+	Microservice string `json:"microservice,omitempty"`
+	LinkID       string `json:"link_uuid,omitempty"`
+	Name         string `json:"name,omitempty"`
+}
+
+type Job struct {
+	ID           string    `json:"uuid"`
+	Name         string    `json:"name"`
+	Status       JobStatus `json:"status"`
+	Microservice string    `json:"microservice"`
+	LinkID       string    `json:"link_uuid"`
+	Tasks        []Task    `json:"tasks"`
+}
+
+type JobStatus int
+
+const (
+	JobStatusUnknown JobStatus = iota
+	JobStatusUserInput
+	JobStatusProcessing
+	JobStatusComplete
+	JobStatusFailed
+)
+
+var jobStatusToString = map[JobStatus]string{
+	JobStatusUnknown:    "UNKNOWN",
+	JobStatusUserInput:  "USER_INPUT",
+	JobStatusProcessing: "PROCESSING",
+	JobStatusComplete:   "COMPLETE",
+	JobStatusFailed:     "FAILED",
+}
+
+var jobStatusToID = map[string]JobStatus{
+	"UNKNOWN":    JobStatusUnknown,
+	"USER_INPUT": JobStatusUserInput,
+	"PROCESSING": JobStatusProcessing,
+	"COMPLETE":   JobStatusComplete,
+	"FAILED":     JobStatusFailed,
+}
+
+// MarshalJSON marshals the enum as a quoted json string
+func (s JobStatus) MarshalJSON() ([]byte, error) {
+	buffer := bytes.NewBufferString(`"`)
+	buffer.WriteString(jobStatusToString[s])
+	buffer.WriteString(`"`)
+	return buffer.Bytes(), nil
+}
+
+// UnmarshalJSON unmashals a quoted json string to the enum value
+func (s *JobStatus) UnmarshalJSON(b []byte) error {
+	var j string
+	err := json.Unmarshal(b, &j)
+	if err != nil {
+		return err
+	}
+	*s = jobStatusToID[j]
+	return nil
+}
+
+type Task struct {
+	ID       string `json:"uuid"`
+	ExitCode uint8  `json:"exit_code"`
+}
+
+func (s *JobsServiceOp) List(ctx context.Context, ID string, r *JobsListRequest) ([]Job, *Response, error) {
+	path := fmt.Sprintf("%s/%s", jobsBasePath, ID)
+
+	req, err := s.client.NewRequestJSON(ctx, "GET", path, r)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	payload := []Job{}
+	resp, err := s.client.Do(ctx, req, &payload)
+
+	return payload, resp, err
+}

--- a/amclient/v2_jobs_test.go
+++ b/amclient/v2_jobs_test.go
@@ -1,0 +1,54 @@
+package amclient
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJobs_List(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/api/v2beta/jobs/e99afef7-90c5-4fd9-bf8f-bed13b3bd4ba/", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `[
+	{
+		"uuid": "624581dc-ec01-4195-9da3-db0ab0ad1cc3",
+		"name": "Check transfer directory for objects",
+		"status": "COMPLETE",
+		"microservice": "Create SIP from Transfer",
+		"link_uuid": "6ce08b95-1b3b-498a-8baa-e595e2ae7466",
+		"tasks": [
+			{
+				"uuid": "491aebbd-457b-4a6e-adf6-87a3a9ee951a",
+				"exit_code": 1
+			}
+		]
+	}
+]`)
+	})
+
+	payload, _, err := client.Jobs.List(ctx, "e99afef7-90c5-4fd9-bf8f-bed13b3bd4ba", &JobsListRequest{
+		LinkID: "6ce08b95-1b3b-498a-8baa-e595e2ae7466",
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, []Job{
+		Job{
+			ID:           "624581dc-ec01-4195-9da3-db0ab0ad1cc3",
+			Name:         "Check transfer directory for objects",
+			Status:       JobStatusComplete,
+			Microservice: "Create SIP from Transfer",
+			LinkID:       "6ce08b95-1b3b-498a-8baa-e595e2ae7466",
+			Tasks: []Task{
+				Task{
+					ID:       "491aebbd-457b-4a6e-adf6-87a3a9ee951a",
+					ExitCode: 1,
+				},
+			},
+		},
+	}, payload)
+}

--- a/amclient/v2_package.go
+++ b/amclient/v2_package.go
@@ -19,11 +19,13 @@ type PackageServiceOp struct {
 var _ PackageService = &PackageServiceOp{}
 
 type PackageCreateRequest struct {
-	Name          string `json:"name"`
-	Type          string `json:"type"`
-	Accession     string `json:"accession"`
-	Path          string `json:"path"`
-	MetadataSetID string `json:"metadata_set_id"`
+	Name              string `json:"name"`
+	Type              string `json:"type"`
+	Path              string `json:"path"`
+	AccessionSystemID string `json:"access_system_id,omitempty"`
+	MetadataSetID     string `json:"metadata_set_id,omitempty"`
+	ProcessingConfig  string `json:"processing_config,omitempty"`
+	AutoApprove       *bool  `json:"auto_approve,omitempty"`
 }
 
 type PackageCreateResponse struct {
@@ -38,7 +40,10 @@ func (s *PackageServiceOp) Create(ctx context.Context, r *PackageCreateRequest) 
 	if r.Type == "" {
 		r.Type = standardTransferType
 	}
-
+	if r.AutoApprove == nil {
+		var approve = true
+		r.AutoApprove = &approve
+	}
 	r.Path = base64.StdEncoding.EncodeToString([]byte(r.Path))
 
 	req, err := s.client.NewRequestJSON(ctx, "POST", path, r)

--- a/amclient/v2_task.go
+++ b/amclient/v2_task.go
@@ -1,0 +1,59 @@
+package amclient
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+const taskBasePath = "api/v2beta/task"
+
+type TaskService interface {
+	Read(context.Context, string) (*TaskDetailed, *Response, error)
+}
+
+type TaskServiceOp struct {
+	client *Client
+}
+
+var _ TaskService = &TaskServiceOp{}
+
+type TaskDateTime struct {
+	time.Time
+}
+
+func (t *TaskDateTime) UnmarshalJSON(data []byte) error {
+	s := string(data)
+	s = s[1 : len(s)-1]
+	td, err := time.Parse("2006-01-02T15:04:05", s)
+	if err != nil {
+		return err
+	}
+	t.Time = td
+	return err
+}
+
+type TaskDetailed struct {
+	ID          string       `json:"uuid"`
+	ExitCode    uint8        `json:"exit_code"`
+	FileID      string       `json:"file_uuid"`
+	Filename    string       `json:"file_name"`
+	TimeCreated TaskDateTime `json:"time_created"`
+	TimeStarted TaskDateTime `json:"time_started"`
+	TimeEnded   TaskDateTime `json:"time_ended"`
+	Duration    uint32       `json:"duration"`
+}
+
+func (s *TaskServiceOp) Read(ctx context.Context, ID string) (*TaskDetailed, *Response, error) {
+	path := fmt.Sprintf("%s/%s", taskBasePath, ID)
+
+	req, err := s.client.NewRequestJSON(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	payload := &TaskDetailed{}
+	resp, err := s.client.Do(ctx, req, payload)
+
+	return payload, resp, err
+}

--- a/amclient/v2_task_test.go
+++ b/amclient/v2_task_test.go
@@ -1,0 +1,43 @@
+package amclient
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTask_Read(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/api/v2beta/task/96acb0a1-525c-456a-9060-51bb84f5f708/", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{
+	"uuid": "96acb0a1-525c-456a-9060-51bb84f5f708",
+	"exit_code": 1,
+	"file_uuid": "e502c0d9-becf-455a-8b20-091526947a09",
+	"file_name": "foobar.txt",
+	"time_created": "2019-06-18T00:00:00",
+	"time_started": "2019-07-18T00:00:00",
+	"time_ended": "2019-08-18T00:00:00",
+	"duration": 4294967295
+}`)
+	})
+
+	payload, _, err := client.Task.Read(ctx, "96acb0a1-525c-456a-9060-51bb84f5f708")
+
+	assert.NoError(t, err)
+	assert.Equal(t, &TaskDetailed{
+		ID:          "96acb0a1-525c-456a-9060-51bb84f5f708",
+		ExitCode:    1,
+		FileID:      "e502c0d9-becf-455a-8b20-091526947a09",
+		TimeCreated: TaskDateTime{Time: time.Date(2019, time.June, 18, 0, 0, 0, 0, time.UTC)},
+		TimeStarted: TaskDateTime{Time: time.Date(2019, time.July, 18, 0, 0, 0, 0, time.UTC)},
+		TimeEnded:   TaskDateTime{Time: time.Date(2019, time.August, 18, 0, 0, 0, 0, time.UTC)},
+		Filename:    "foobar.txt",
+		Duration:    4294967295,
+	}, payload)
+}

--- a/amclient/wait.go
+++ b/amclient/wait.go
@@ -1,0 +1,86 @@
+package amclient
+
+import (
+	"context"
+	"time"
+
+	"github.com/cenkalti/backoff/v3"
+	"github.com/pkg/errors"
+)
+
+const (
+	// maxWait determines for how long is our retry strategy willing to wait
+	// for the underlying operation to complete.
+	maxWait = time.Hour * 8
+
+	// workflowLinkStoreAIPID is the workflow link ID for "Store the AIP".
+	// There's some obvious API leaking here. On the bright side, link IDs are
+	// unlikely to change as opposed to link labels which may change more
+	// frequently.
+	workflowLinkStoreAIPID = "20515483-25ed-4133-b23e-5bb14cab8e22"
+)
+
+// WaitUntilStored blocks until the AIP generated after a transfer is confirmed
+// to be stored. The implementation is based on TransferService.Status and
+// JobsService.List.
+//
+// The retry gives up as soon as one of the following events occur:
+// * The caller cancels the context.
+// * The total retry period exceeds maxWait.
+//
+// TODO: we may want to give up earlier in case of specific errors, e.g. if
+// TransferService.Status returns errors repeatedly?
+func WaitUntilStored(ctx context.Context, c *Client, transferID string) (SIPID string, err error) {
+	expBackoff := backoff.NewExponentialBackOff()
+	expBackoff.MaxElapsedTime = maxWait
+	ctxBackoff := backoff.WithContext(expBackoff, ctx)
+
+	err = backoff.Retry(func() error {
+
+		ctx, cancel := context.WithTimeout(ctx, time.Duration(time.Second*1))
+		defer cancel()
+
+		// Retrieve SIPID.
+		if SIPID == "" {
+			resp, _, err := c.Transfer.Status(ctx, transferID)
+			if err != nil {
+				return errors.Wrap(err, "TransferService.Status request failed")
+			}
+			sid, ok := resp.SIP()
+			if !ok {
+				return errors.New("SIP not created yet")
+			}
+			SIPID = sid
+		}
+
+		// Retrieve status.
+		jobs, _, err := c.Jobs.List(ctx, SIPID, &JobsListRequest{
+			LinkID: workflowLinkStoreAIPID,
+		})
+		if err != nil {
+			return errors.Wrap(err, "JobsService.List request failed")
+		}
+		var match *Job
+		for _, job := range jobs {
+			if job.LinkID == workflowLinkStoreAIPID {
+				match = &job
+				break
+			}
+		}
+		var notStoredYetErr = errors.New("AIP not stored yet")
+		if match == nil {
+			return notStoredYetErr
+		}
+		switch match.Status {
+		case JobStatusFailed:
+			return backoff.Permanent(errors.New("AIP store operation failed"))
+		case JobStatusComplete:
+			return nil
+		default:
+			return notStoredYetErr
+		}
+
+	}, ctxBackoff)
+
+	return SIPID, err
+}

--- a/amclient/wait_test.go
+++ b/amclient/wait_test.go
@@ -1,0 +1,37 @@
+package amclient_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/JiscRDSS/rdss-archivematica-channel-adapter/amclient"
+)
+
+func ExampleWaitUntilStored() {
+	ctx := context.Background()
+	client := amclient.NewClient(http.DefaultClient, "http://127.0.0.1:62080/api", "test", "test")
+
+	// Start transfer.
+	ctxTimeout, cancel := context.WithTimeout(ctx, time.Hour*2)
+	defer cancel()
+	payload, _, err := client.Package.Create(ctxTimeout, &amclient.PackageCreateRequest{
+		Name:             "images",
+		Type:             "standard",
+		Path:             "/home/archivematica/archivematica-sampledata/SampleTransfers/Images",
+		ProcessingConfig: "automated",
+	})
+	if err != nil {
+		log.Fatal("Package.Create failed: ", err)
+	}
+
+	// Wait until the AIP is stored.
+	SIPID, err := amclient.WaitUntilStored(ctx, client, payload.ID)
+	if err != nil || SIPID == "" {
+		log.Fatal("WaitUntilStored failed: ", err)
+	}
+
+	fmt.Printf("Transfer stored successfully! AIP %s", SIPID)
+}


### PR DESCRIPTION
- [1/4] [Upgrade to RDSS MAS v4.0.0](https://github.com/JiscRDSS/rdss-archivematica-channel-adapter/pull/110)
- [2/4] [Add SQS/SNS backend](https://github.com/JiscRDSS/rdss-archivematica-channel-adapter/pull/111)
- **[3/4] Publish PreservationEvent message**
- [4/4] [Support multitenancy](https://github.com/JiscRDSS/rdss-archivematica-channel-adapter/pull/113)

---

The message is published only when the AIP is stored hence this PR brings changes to the `amclient` package to allow users wait until such action completes.