### PR TITLE
Add no-op invalid/error queues

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,16 @@
 
 # RDSS Archivematica Channel Adapter
 
-- [Introduction](#Introduction)
-- [Installation](#Installation)
-- [Configuration](#Configuration)
-  - [Configuration file](#Configuration-file)
-  - [Environment variables](#Environment-variables)
-  - [Service dependencies](#Service-dependencies)
-  - [AWS service client configuration](#AWS-service-client-configuration)
-  - [Registry of Archivematica pipelines](#Registry-of-Archivematica-pipelines)
-- [Metrics and runtime profiling data](#Metrics-and-runtime-profiling-data)
-- [Contributing](#Contributing)
+- [Introduction](#introduction)
+- [Installation](#installation)
+- [Configuration](#configuration)
+  - [Configuration file](#configuration-file)
+  - [Environment variables](#environment-variables)
+  - [Service dependencies](#service-dependencies)
+  - [AWS service client configuration](#aws-service-client-configuration)
+  - [Registry of Archivematica pipelines](#registry-of-archivematica-pipelines)
+- [Metrics and runtime profiling data](#metrics-and-runtime-profiling-data)
+- [Contributing](#contributing)
 
 ## Introduction
 
@@ -21,28 +21,49 @@ RDSS Archivematica Channel Adapter is an implementation of a channel adapter for
 
 This application is distributed as a single static binary file that you can download from the [Releases](https://github.com/JiscRDSS/rdss-archivematica-channel-adapter/releases) page. You can use a process manager such [systemd](https://www.linode.com/docs/quick-answers/linux/start-service-at-boot/) to run it.
 
-The following example runs the application using the Docker image.
+The following example runs the application server using the Docker image.
 
     $ docker run \
         --tty --rm \
-        --env "RDSS_ARCHIVEMATICA_ADAPTER_LOGGING.LEVEL=WARNING" \
-        artefactual/rdss-archivematica-channel-adapter \
+        --env "RDSS_ARCHIVEMATICA_ADAPTER_ADAPTER.QUEUE_RECV_MAIN_ADDR=https://queue.amazonaws.com/444455556666/recv" \
+        --env "RDSS_ARCHIVEMATICA_ADAPTER_ADAPTER.QUEUE_SEND_MAIN_ADDR=arn:aws:sqs:us-east-2:444455556666:send" \
+        --env "AWS_REGION=us-east-1" \
+        --env "AWS_ACCESS_KEY=1234" \
+        --env "AWS_SECRET_KEY=5678" \
+        artefactual/rdss-archivematica-channel-adapter:latest \
             server
 
-The example above uses the `server` subcommand and passes configuration attributes via the environment.
+Read the [configuration][#Configuration] section before you proceed with the deployment.
 
 ## Configuration
 
-Configuration defaults are included in the source code ([config.go](./app/config.go)). Use it as a reference since it lists all the attributes available including descriptions. We use the [TOML configuration file format](https://en.wikipedia.org/wiki/TOML).
+All configuration attributes are described in the source code. See [config.go](./app/config.go) for more.
 
-Inject custom configuration attributes via a configuration file and/or environment variables.
+There are sensible defaults in place. You need to pay spetial attention to the attributes below and tweak them according to your environment:
+
+- `adapter.processing_table`
+- `adapter.repository_table`
+- `adapter.registry_table`
+- `adapter.queue_recv_main_addr`
+- `adapter.queue_send_main_addr`
 
 ### Configuration file
 
-The configuration file can be indicated via the `--config` command-line argument. When undefined, the application attempts to read from one of the following locations:
+We use the [TOML configuration file format](https://en.wikipedia.org/wiki/TOML). The configuration file can be indicated via the `--config` command-line argument. When undefined, the application attempts to read from one of the following locations:
 
 - `$HOME/.config/rdss-archivematica-channel-adapter.toml`
 - `/etc/archivematica/rdss-archivematica-channel-adapter.toml`
+
+This is a minimal configuration example:
+
+```toml
+[adapter]
+processing_table = "adapter_processing"
+repository_table = "repository_processing"
+registry_table = "registry_processing"
+queue_recv_main_addr = "https://queue.amazonaws.com/444455556666/recv"
+queue_send_main_addr = "arn:aws:sqs:us-east-2:444455556666:send"
+```
 
 ### Environment variables
 

--- a/app/cmd_server.go
+++ b/app/cmd_server.go
@@ -11,6 +11,7 @@ import (
 	"github.com/JiscRDSS/rdss-archivematica-channel-adapter/adapter"
 	"github.com/JiscRDSS/rdss-archivematica-channel-adapter/broker"
 	"github.com/JiscRDSS/rdss-archivematica-channel-adapter/s3"
+	"github.com/JiscRDSS/rdss-archivematica-channel-adapter/version"
 
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
@@ -28,6 +29,7 @@ func NewCmdServer(logger logrus.FieldLogger, config *Config) *cobra.Command {
 		Use:   "server",
 		Short: "Start the application server",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			logger.WithField("v", version.VERSION).Info("Starting server...")
 			return doServer(logger, config)
 		},
 	}

--- a/app/config.go
+++ b/app/config.go
@@ -66,7 +66,10 @@ queue_recv_main_addr = ""
 #
 # AWS SNS topic ARN, e.g. "arn:aws:sqs:us-east-2:444455556666:queue1".
 #
-# The adapter will publish to this queue.
+# The adapter will publish to these queues.
+#
+# It is possible to use empty strings in the error and invalid addresses.
+# When that's the case, the adapter will send events to the logger instead.
 #
 queue_send_main_addr = ""
 queue_send_error_addr = ""

--- a/app/config.go
+++ b/app/config.go
@@ -20,6 +20,12 @@ const defaultConfig = `# RDSS Archivematica Channel Adapter
 #
 level = "INFO"
 
+#
+# Logging format.
+# Supported values: "text", "json"
+#
+format = "text"
+
 ################################## ADAPTER ####################################
 
 [adapter]
@@ -96,7 +102,8 @@ type Config struct {
 	v *viper.Viper
 
 	Logging struct {
-		Level string `mapstructure:"level"`
+		Level  string `mapstructure:"level"`
+		Format string `mapstructure:"format"`
 	} `mapstructure:"logging"`
 
 	Adapter struct {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/JiscRDSS/rdss-archivematica-channel-adapter
 go 1.12
 
 require (
-	github.com/aws/aws-sdk-go v1.21.4
+	github.com/aws/aws-sdk-go v1.21.7
 	github.com/cenkalti/backoff/v3 v3.0.0
 	github.com/go-logfmt/logfmt v0.4.0
 	github.com/golang/protobuf v1.3.2 // indirect
@@ -31,7 +31,7 @@ require (
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415
 	github.com/xeipuuv/gojsonschema v0.0.0-20180207214316-8bcffc811467
 	golang.org/x/net v0.0.0-20190724013045-ca1201d0de80 // indirect
-	golang.org/x/sys v0.0.0-20190712062909-fae7ac547cb7 // indirect
+	golang.org/x/sys v0.0.0-20190730183949-1393eb018365 // indirect
 	golang.org/x/text v0.3.2 // indirect
-	golang.org/x/tools v0.0.0-20190724185037-8aa4eac1a7c1
+	golang.org/x/tools v0.0.0-20190729092621-ff9f1409240a
 )

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,8 @@ github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAE
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/aws/aws-sdk-go v1.21.4 h1:1xB+x6Dzev8ETmeHEiSfUVbIzmC/0EyFfXMkJpzKPCE=
-github.com/aws/aws-sdk-go v1.21.4/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/aws/aws-sdk-go v1.21.7 h1:ml+k7szyVaq4YD+3LhqOGl9tgMTqgMbpnuUSkB6UJvQ=
+github.com/aws/aws-sdk-go v1.21.7/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0 h1:HWo1m869IqiPhD389kmkxeTalrjNbbJTC8LXupb+sl0=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
@@ -166,6 +166,8 @@ github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHo
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
 github.com/xeipuuv/gojsonschema v0.0.0-20180207214316-8bcffc811467 h1:HisfGWpeT1m5PRfKjbAAMkfQWGYUuPg8Szy2oN9zzv8=
 github.com/xeipuuv/gojsonschema v0.0.0-20180207214316-8bcffc811467/go.mod h1:5yf86TLmAcydyeJq5YvxkGPE2fm/u4myDekKRoLuqhs=
+github.com/xeipuuv/gojsonschema v1.1.0 h1:ngVtJC9TY/lg0AA/1k48FYhBrhRoFlEmWzsehpNAaZg=
+github.com/xeipuuv/gojsonschema v1.1.0/go.mod h1:5yf86TLmAcydyeJq5YvxkGPE2fm/u4myDekKRoLuqhs=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
@@ -198,8 +200,8 @@ golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20190712062909-fae7ac547cb7 h1:LepdCS8Gf/MVejFIt8lsiexZATdoGVyp5bcyS+rYoUI=
-golang.org/x/sys v0.0.0-20190712062909-fae7ac547cb7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190730183949-1393eb018365 h1:SaXEMXhWzMJThc05vu6uh61Q245r4KaWMrsTedk0FDc=
+golang.org/x/sys v0.0.0-20190730183949-1393eb018365/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
@@ -209,8 +211,8 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd h1:/e+gpKk9r3dJobndpTytxS2gOy6m5uvpg+ISQoEcusQ=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
-golang.org/x/tools v0.0.0-20190724185037-8aa4eac1a7c1 h1:JwHzEZwWOyWUIR+OxPKGQGUfuOp/feyTesu6DEwqvsM=
-golang.org/x/tools v0.0.0-20190724185037-8aa4eac1a7c1/go.mod h1:jcCCGcm9btYwXyDqrUWc6MKQKKGJCWEQ3AfLSRIbEuI=
+golang.org/x/tools v0.0.0-20190729092621-ff9f1409240a h1:mEQZbbaBjWyLNy0tmZmgEuQAR8XOQ3hL8GYi3J/NG64=
+golang.org/x/tools v0.0.0-20190729092621-ff9f1409240a/go.mod h1:jcCCGcm9btYwXyDqrUWc6MKQKKGJCWEQ3AfLSRIbEuI=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=

--- a/integration/scripts/example_run.sh
+++ b/integration/scripts/example_run.sh
@@ -5,7 +5,7 @@ set -e
 hash rdss-archivematica-channel-adapter 2>/dev/null || (cd ../.. && make install)
 
 env \
-	RDSS_ARCHIVEMATICA_ADAPTER_LOGGING.LEVEL="debug" \
+	RDSS_ARCHIVEMATICA_ADAPTER_LOGGING.LEVEL="info" \
 	RDSS_ARCHIVEMATICA_ADAPTER_ADAPTER.PROCESSING_TABLE="rdss_archivematica_adapter_processing_state" \
 	RDSS_ARCHIVEMATICA_ADAPTER_ADAPTER.REPOSITORY_TABLE="rdss_archivematica_adapter_local_data_repository" \
 	RDSS_ARCHIVEMATICA_ADAPTER_ADAPTER.REGISTRY_TABLE="rdss_archivematica_adapter_registry" \


### PR DESCRIPTION
It is not clear whether in practice the Error Message Queue or Invalid Message
Queue are going to be utilised as described in the specification.

This PR updates the broker package so messages are not published into the
topics but logged instead, when their ARNs have been set to empty string.

The two relevant config attributes are:

- `adapter.queue_send_error_addr`
- `adapter.queue_send_invalid_addr`

These are examples of logged events for both the invalid and error queues:

	time="2019-07-25T13:51:15-07:00" level=warning msg="[GENERR001]: invalid character 'i' looking for beginning of value" cmd=server error-queue="invalid[disabled]"
	time="2019-07-25T13:51:21-07:00" level=warning msg="[GENERR006]: 1: unknown tenantJiscID" cmd=server error-queue="error[disabled]"

The logger learns a new config attribute (`logging.format`) to emit JSON-formatted structured log events.